### PR TITLE
Support viewing files and diff from deleted branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.swp
+*.buildpath
+*.project

--- a/SourceWebSVN/SourceWebSVN.php
+++ b/SourceWebSVN/SourceWebSVN.php
@@ -52,7 +52,8 @@ class SourceWebSVNPlugin extends SourceSVNPlugin {
 			return '';
 		}
 		return $p_repo->info['websvn_url'] . 'filedetails.php?repname=' . urlencode( $p_repo->info['websvn_name'] ) .
-			'&rev=' . urlencode( $p_changeset->revision ) . '&path=' . urlencode( $p_file->filename ) . '&sc=1';
+			'&rev=' . urlencode( $p_changeset->revision ) . '&peg=' . urlencode( $p_changeset->revision ) .
+			'&path=' . urlencode( $p_file->filename ) . '&sc=1';
 	}
 
 	public function url_diff( $p_repo, $p_changeset, $p_file ) {
@@ -60,7 +61,8 @@ class SourceWebSVNPlugin extends SourceSVNPlugin {
 			return '';
 		}
 		return $p_repo->info['websvn_url'] . 'diff.php?repname=' . urlencode( $p_repo->info['websvn_name'] ) .
-			'&rev=' . urlencode( $p_changeset->revision ) . '&path=' . urlencode( $p_file->filename ) . '&sc=1';
+			'&rev=' . urlencode( $p_changeset->revision ) . '&peg=' . urlencode( $p_changeset->revision ) .
+			'&path=' . urlencode( $p_file->filename ) . '&sc=1';
 	}
 
 	public function update_repo_form( $p_repo ) {


### PR DESCRIPTION
When trying to see files or view diff between files from a branch that has
been marked as deleted (like a reintegrated feature branch), websvn
displayed an error saying that file does not exist at that specific
revision, even though it actually does. Adding peg=<rev> fixes this.

Fixes ticket http://leetcode.net/mantis/view.php?id=237
