### PR TITLE
Github: Bugfix: Wrong comparison of repository name

### DIFF
--- a/SourceGithub/SourceGithub.php
+++ b/SourceGithub/SourceGithub.php
@@ -227,7 +227,7 @@ endif; ?></td>
 			$t_repo = new SourceRepo( $t_row['type'], $t_row['name'], $t_row['url'], $t_row['info'] );
 			$t_repo->id = $t_row['id'];
 
-			if ( $t_repo->info['hub_reponame'] == $t_reponame ) {
+			if ( $t_row['name'] == $t_reponame ) {
 				return array( 'repo' => $t_repo, 'data' => $t_data );
 			}
 		}


### PR DESCRIPTION
On Github the repository names musn't be lowercase and without blanks.

Because of that the comparison is wrong.
The repository name send in the payload-data by Github could be something like
`RePoSiToy_NamE`
But the data for `hub_reponame` has to be entered lowercase in the settings:
https://github.com/mantisbt-plugins/source-integration/blob/master/SourceGithub/lang/strings_english.txt#L12

So if the two values differ no import is possible.
