### PR TITLE
Take back some improvements / fixes from SourceWebSVN plugin to SourceSFSVN

### DIFF
--- a/SourceSFSVN/SourceSFSVN.php
+++ b/SourceSFSVN/SourceSFSVN.php
@@ -48,11 +48,13 @@ class SourceSFSVNPlugin extends SourceSVNPlugin {
 	}
 
 	public function url_file( $p_repo, $p_changeset, $p_file ) {
-		if ( $p_file->action == 'rm' ) {
-			return '';
-		}
+		# if the file has been removed, it doesn't exist in current revision
+		# so we generate a link to (current revision - 1)
+		$t_revision = ($p_file->action == 'rm')
+					? $p_changeset->revision - 1
+					: $p_changeset->revision;
 		return $this->sf_url( $p_repo ) . urlencode( $p_file->filename ) .
-			'?view=markup&pathrev=' . urlencode( $p_changeset->revision );
+			'?view=markup&pathrev=' . urlencode( $t_revision );
 	}
 
 	public function url_diff( $p_repo, $p_changeset, $p_file ) {


### PR DESCRIPTION
This follows discussion on https://github.com/dregad/source-integration/commit/deba255e873879791c339c4efb5e46cef95f2d34#commitcomment-2713308

Changesets https://github.com/mantisbt-plugins/source-integration/commit/deba255e873879791c339c4efb5e46cef95f2d34 and https://github.com/mantisbt-plugins/source-integration/commit/c11a010d491ec7f80fd4b842dc8770098af2fc44 for SourceWebSVN apply _mutatis mutandis_ to SourceSFSVN
