### PR TITLE
SVN: support svn:log revprop changes

### DIFF
--- a/Source/Source.API.php
+++ b/Source/Source.API.php
@@ -993,14 +993,25 @@ class SourceChangeset {
 			$t_params = array();
 
 			foreach( $t_bugs_added as $t_bug_id ) {
-				$t_query .= ( $t_count == 0 ? '' : ', ' ) .
-					'(' . db_param() . ', ' . db_param() . ')';
-				$t_params[] = $this->id;
-				$t_params[] = $t_bug_id;
-				$t_count++;
+				$t_params_2 = array();
+				$t_query_2 = "SELECT COUNT(*) AS b FROM $t_bug_table WHERE change_id=" . db_param() . " AND bug_id=" . db_param();
+				$t_params_2[] = $this->id;
+				$t_params_2[] = $t_bug_id;
+				$t_result = db_query_bound( $t_query_2, $t_params_2 );
+				$t_row = db_fetch_array( $t_result );
+				if ( $t_row['b'] < 1 ) {
+					// Wrap this in a "is this already in the DB?" test...
+					$t_query .= ( $t_count == 0 ? '' : ', ' ) .
+						'(' . db_param() . ', ' . db_param() . ')';
+					$t_params[] = $this->id;
+					$t_params[] = $t_bug_id;
+					$t_count++;
+				}
 			}
 
-			db_query_bound( $t_query, $t_params );
+			if ( substr( $t_query, -1)==")" ) {
+				db_query_bound( $t_query, $t_params );
+			}
 
 			foreach( $t_bugs_added as $t_bug_id ) {
 				plugin_history_log( $t_bug_id, 'changeset_attached', '',

--- a/Source/pages/checkin.php
+++ b/Source/pages/checkin.php
@@ -61,6 +61,9 @@ if ( !$t_valid ) {
 # Let plugins try to intepret POST data before we do
 $t_predata = event_signal( 'EVENT_SOURCE_PRECOMMIT' );
 
+# Try to gracefully detect revprop changes flag
+$f_revprop = gpc_get_bool( 'revprop', false );
+
 # Expect plugin data in form of array( repo_name, data )
 if ( is_array( $t_predata ) && count( $t_predata ) == 2 ) {
 	$t_repo = $t_predata['repo'];
@@ -79,7 +82,7 @@ if ( is_null( $t_repo ) ) {
 $t_vcs = SourceVCS::repo( $t_repo );
 
 # Let the plugins handle commit data
-$t_changesets = $t_vcs->commit( $t_repo, $f_data );
+$t_changesets = $t_vcs->commit( $t_repo, $f_data, $f_revprop );
 
 # Changesets couldn't be loaded apparently
 if ( !is_array( $t_changesets ) ) {

--- a/SourceSVN/SourceSVN.php
+++ b/SourceSVN/SourceSVN.php
@@ -189,7 +189,7 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 		}
 	}
 
-	public function commit( $p_repo, $p_data ) {
+	public function commit( $p_repo, $p_data, $p_revprop=false ) {
 		if ( preg_match( '/(\d+)/', $p_data, $p_matches ) ) {
 			$svn = $this->svn_call( $p_repo );
 
@@ -197,12 +197,14 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 			$t_revision = $p_matches[1];
 			$t_svnlog_xml = shell_exec( "$svn log -v $t_url -r$t_revision --xml" );
 
-			if ( SourceChangeset::exists( $p_repo->id, $t_revision ) ) {
-				echo "Revision $t_revision already committed!\n";
-				return null;
+			if ( $p_revprop == false ) {
+				if ( SourceChangeset::exists( $p_repo->id, $t_revision ) ) {
+					echo "Revision $t_revision already committed!\n";
+					return null;
+				}
 			}
 
-			return $this->process_svn_log_xml( $p_repo, $t_svnlog_xml );
+			return $this->process_svn_log_xml( $p_repo, $t_svnlog_xml, $p_revprop );
 		}
 	}
 
@@ -353,9 +355,10 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 	 * Parse the svn log output (with --xml option)
 	 * @param SourceRepo SVN repository object
 	 * @param string SVN log (XML formated)
+	 * @param boolean REVPROP change flag
 	 * @return SourceChangeset[] Changesets for the provided input (empty on error)
 	 */
-	private function process_svn_log_xml( $p_repo, $p_svnlog_xml ) {
+	private function process_svn_log_xml( $p_repo, $p_svnlog_xml, $p_revprop = false ) {
 		$t_changesets = array();
 		$t_changeset = null;
 		$t_comments = '';
@@ -444,6 +447,18 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 			// Save changeset and append to array
 			if( !is_null( $t_changeset) ) {
 				if( !is_blank( $t_changeset->branch ) ) {
+					if( $p_revprop ) {
+						echo "  REVPROP change detected.\n";
+						$t_existing_changeset = SourceChangeset::load_by_revision( $p_repo, $t_changeset->revision );
+						$t_changeset->id = $t_existing_changeset->id;
+						$t_changeset->user_id = $t_existing_changeset->user_id;
+						$t_changeset->files = $t_existing_changeset->files;
+						$t_old_bugs = array_unique( Source_Parse_Buglinks( $t_existing_changeset->message ));
+						$t_new_bugs = array_unique( Source_Parse_Buglinks( $t_changeset->message ));
+						if( count( $t_old_bugs ) >= count( $t_new_bugs )) {
+							$t_changeset->__bugs = array_diff( $t_old_bugs, $t_new_bugs );
+						}
+					}
 					$t_changeset->save();
 					$t_changesets[] = $t_changeset;
 				}

--- a/SourceSVN/post-revprop-change.tmpl
+++ b/SourceSVN/post-revprop-change.tmpl
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Copyright (c) 2014 GGP Systems Limited
+# Licensed under the BSD (3-clause) license
+
+REPOS="$1"
+REV="$2"
+PROP="$4"
+
+if [ "$PROP" = 'svn:log' ]; then
+	URL="http://localhost/mantisbt/plugin.php?page=Source/checkin"
+	PROJECT="Repository Name"
+	API_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+	LOG_FILE=`mktemp /tmp/svn_${PROJECT}_${REV}_log.XXX`
+
+	CURL=/usr/bin/curl
+
+	${CURL} -d "repo_name=${PROJECT}" -d "data=${REV}" -d "revprop=TRUE" -d "api_key=${API_KEY}" ${URL} >> ${LOG_FILE}
+fi
+


### PR DESCRIPTION
I've added rudimentary support for svn:log revprop changes to permit SCI to keep repositories current when you have developers that don't get commit messages right first time. Doesn't deal with reopening "accidentally" closed issues, if you guys can figure that one out you'll be Gods in my eyes.
