### PR TITLE
Update for MantisColumn::display()

### DIFF
--- a/Source/classes/RelatedChangesetsColumn.class.php
+++ b/Source/classes/RelatedChangesetsColumn.class.php
@@ -45,7 +45,7 @@ class SourceRelatedChangesetsColumn extends MantisColumn {
 		}
 	}
 
-	public function display( $p_bug, $p_columns_target ) {
+	public function display( BugData $p_bug, $p_columns_target ) {
 		plugin_push_current( 'Source' );
 
 		if ( isset( $this->changeset_cache[ $p_bug->id ] ) ) {


### PR DESCRIPTION
Declaration of SourceRelatedChangesetsColumn::display() must be compatible with that of MantisColumn::display()
