### PR TITLE
Fix Gitlab plugin to handle payload without JSON data

### DIFF
--- a/SourceGitlab/SourceGitlab.php
+++ b/SourceGitlab/SourceGitlab.php
@@ -200,11 +200,14 @@ public function update_repo_form( $p_repo ) {
 
 	public function precommit() {
 		$f_payload = file_get_contents( "php://input" );
-		if ( is_null( $f_payload ) ) {
+		if( is_null( $f_payload ) ) {
 			return;
 		}
 
 		$t_data = json_decode( $f_payload, true );
+		if( is_null( $t_data ) ) {
+			return;
+		}
 
 		$t_repoid = $t_data['project_id'];
 		$t_repo_table = plugin_table( 'repository', 'Source' );


### PR DESCRIPTION
We have a Mantis installation managing projects under SVN, Git with Gitweb, and now we are installing a Gitlab server.

Problem is the old Git server is using a hook to send POST data not in JSON format, and this screw the Gitlab plugin,
that bypass all other plugins and try to retrieve changeset from the first repository matching null repoid (which is the first repo in mantis database, a SVN repo)

=> add a check for null data after the check for empy payload does the job nicely