### PR TITLE
Fix Gitlab plugin to extract full branchname when containing slashes

### DIFF
--- a/SourceGitlab/SourceGitlab.php
+++ b/SourceGitlab/SourceGitlab.php
@@ -231,7 +231,8 @@ public function update_repo_form( $p_repo ) {
 			$t_commits[] = $t_commit['id'];
 		}
 
-		$t_refData = split( '/', $p_data['ref'] );
+		# extract branch name 'refs/heads/issue/branch-description' => ['refs', 'heads', 'issue/branch-description']
+		$t_refData = explode( '/', $p_data['ref'], 3 );
 		$t_branch = $t_refData[2];
 
 		return $this->import_commits( $p_repo, $t_commits, $t_branch );


### PR DESCRIPTION
 - convert deprecated split() function into explode() (same parameters)
 - use the limit parameter set to 3, to return an array of at most 3 strings,
   the last one containing everything after the second slash

Example:
'refs/heads/issue/branch-description' => ['refs', 'heads', 'issue/branch-description']