### PR TITLE
Changes to work with 1.3.0

### DIFF
--- a/Source/Source.php
+++ b/Source/Source.php
@@ -19,7 +19,7 @@ class SourcePlugin extends MantisPlugin {
 
 		$this->version = self::$framework_version;
 		$this->requires = array(
-			'MantisCore' => '1.2.0',
+			'MantisCore' => '1.3.0',
 		);
 		$this->uses = array(
 			'jQuery' => '1.3',

--- a/Source/classes/RelatedChangesetsColumn.class.php
+++ b/Source/classes/RelatedChangesetsColumn.class.php
@@ -44,7 +44,7 @@ class SourceRelatedChangesetsColumn extends MantisColumn {
 			}
 		}
 	}
-	// PHP Fatal error:  Declaration of SourceRelatedChangesetsColumn::display() must be compatible with MantisColumn::display(BugData $p_bug, $p_columns_target) 
+	
 	public function display( BugData $p_bug, $p_columns_target ) {
 		plugin_push_current( 'Source' );
 

--- a/Source/classes/RelatedChangesetsColumn.class.php
+++ b/Source/classes/RelatedChangesetsColumn.class.php
@@ -44,8 +44,8 @@ class SourceRelatedChangesetsColumn extends MantisColumn {
 			}
 		}
 	}
-
-	public function display( $p_bug, $p_columns_target ) {
+	// PHP Fatal error:  Declaration of SourceRelatedChangesetsColumn::display() must be compatible with MantisColumn::display(BugData $p_bug, $p_columns_target) 
+	public function display( BugData $p_bug, $p_columns_target ) {
 		plugin_push_current( 'Source' );
 
 		if ( isset( $this->changeset_cache[ $p_bug->id ] ) ) {

--- a/SourceGithub/SourceGithub.php
+++ b/SourceGithub/SourceGithub.php
@@ -19,7 +19,7 @@ class SourceGithubPlugin extends MantisSourcePlugin {
 
 		$this->version = '0.18';
 		$this->requires = array(
-			'MantisCore' => '1.2.16',
+			'MantisCore' => '1.3.0',
 			'Source' => '0.18',
 		);
 


### PR DESCRIPTION
Install buttons missing for deprecated dependencies. Fixed the PHP Fatal error:  Declaration of SourceRelatedChangesetsColumn::display() must be compatible with MantisColumn::display(BugData $p_bug, $p_columns_target). Everything else worked.