### PR TITLE
Fixes import abort when trying to import inital large repositories 

### DIFF
--- a/Source/Source.API.php
+++ b/Source/Source.API.php
@@ -997,7 +997,7 @@ class SourceChangeset {
 		}
 
 		if ( count( $t_bugs_added ) > 0 ) {
-			$t_query = "INSERT INTO $t_bug_table ( change_id, bug_id ) VALUES ";
+			$t_query = "INSERT IGNORE INTO $t_bug_table ( change_id, bug_id ) VALUES ";
 
 			$t_count = 0;
 			$t_params = array();


### PR DESCRIPTION
... since a duplicate change_id / bug_id is reported for table mantis_plugin_Source_bug_table.

I was trying to import a repository using gitlab plugin.
