### PR TITLE
fix bug : the Cgit script cannot filter out the decoration tag.

### DIFF
--- a/SourceCgit/SourceCgit.php
+++ b/SourceCgit/SourceCgit.php
@@ -279,7 +279,7 @@ class SourceCgitPlugin extends MantisSourcePlugin {
 	 * @return string
 	 */
 	public function commit_message( $p_input ) {
-		preg_match( "#<div class='commit-subject'>(.*?)(<a class=|</div>)#", $p_input, $t_matches);
+		preg_match( "#<div class='commit-subject'>(.*?)(<span class='decoration'>|<a class=|</div>)#", $p_input, $t_matches);
 		$t_message = trim( str_replace( '<br/>', PHP_EOL, $t_matches[1] ) );
 
 		# Strip ref links and signoff spans from commit message

--- a/SourceCgit/post-receive.sample
+++ b/SourceCgit/post-receive.sample
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# This is a secret password to be used by services sending commit data to Mantis.
+API_KEY=6dcde9b4c68c4507f68b6ec3
+# Repository ID
+ID=11
+
+CURL=/usr/bin/curl
+
+URL="http://localhost/mantis/plugin.php?page=Source/import&api_key=${API_KEY}&id=${ID}"
+
+echo "Updating Changeset to Mantis Bug Tracker"
+${CURL} ${URL}


### PR DESCRIPTION
The commit subjects imported from Cgit  ALL followd by an unclosed span tag `<span class='decoration'>`.