### PR TITLE
Hide edit controls on changeset details page for unauthorized users

### DIFF
--- a/Source/pages/view.php
+++ b/Source/pages/view.php
@@ -4,7 +4,7 @@
 # Licensed under the MIT license
 
 access_ensure_global_level( plugin_config_get( 'view_threshold' ) );
-$t_can_update = access_has_project_level( plugin_config_get( 'update_threshold' ) );
+$t_can_update = access_has_global_level( plugin_config_get( 'update_threshold' ) );
 
 require_once( config_get( 'plugin_path' ) . 'Source/Source.ViewAPI.php' );
 


### PR DESCRIPTION
If a user has sufficient privileges at least in one project he is allowed to see "Attach", "Detach", and "Edit" buttons for any changeset on Details page (Source/view&id=<changeset_id>).

For example if Source plugin settings are: View Threshold: viewer, Update Threshold: developer
And the user rights are: Global: viewer, Some project: developer

The user will see those buttons for any changeset (attached to any bug of any project, or not attached at all), if he change the current project to Some project in drop-down list.

This would look like a security issue, but these buttons do not actually work, because all actions are checked for global permissions afterwards.

This commit fixes the issue described above.