### PR TITLE
Add binary files whose filenames contain spaces into changeset

### DIFF
--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -268,7 +268,7 @@ class SourceHgWebPlugin extends MantisSourcePlugin {
 
 			$t_changeset->author_email = empty($t_commit['author_email'])? '': $t_commit['author_email'];
 
-			preg_match_all('#diff[\s]*-r[\s]([^\s]*)[\s]*-r[\s]([^\s]*)[\s]([^\n]*)\n(Binary file[\s]([^\s]*)[\s]has changed|\-{3}[\s](/dev/null)?[^\t]*[^\n]*\n\+{3}[\s](/dev/null)?[^\t]*\t[^\n]*)#', $p_input, $t_matches, PREG_SET_ORDER);
+			preg_match_all('#diff[\s]*-r[\s]([^\s]*)[\s]*-r[\s]([^\s]*)[\s]([^\n]*)\n(Binary file[\s]([^\n]*)[\s]has changed|\-{3}[\s](/dev/null)?[^\t]*[^\n]*\n\+{3}[\s](/dev/null)?[^\t]*\t[^\n]*)#', $p_input, $t_matches, PREG_SET_ORDER);
 
 			$t_commit['files'] = array();
 

--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -153,7 +153,7 @@ class SourceHgWebPlugin extends MantisSourcePlugin {
 			$t_branch = 'default';
 		}
 
-		$t_branches = map( 'trim', explode( ',', $t_branch ) );
+		$t_branches = array_map( 'trim', explode( ',', $t_branch ) );
 		$t_changesets = array();
 
 		$t_changeset_table = plugin_table( 'changeset', 'Source' );


### PR DESCRIPTION
Update HgWeb filename match pattern. So that binary files whose filenames contain spaces could be recognized in the changeset.

test sample:
diff -r 000000000000 -r 4f849d92debe 01 foo/bar.jpg
Binary file 01 foo/bar.jpg has changed