### PR TITLE
Add binary files whose filenames contain spaces/Unicode characters into the changeset.

### DIFF
--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -268,7 +268,7 @@ class SourceHgWebPlugin extends MantisSourcePlugin {
 
 			$t_changeset->author_email = empty($t_commit['author_email'])? '': $t_commit['author_email'];
 
-			preg_match_all('#diff[\s]*-r[\s]([^\s]*)[\s]*-r[\s]([^\s]*)[\s]([^\n]*)\n(Binary file[\s]([^\s]*)[\s]has changed|\-{3}[\s](/dev/null)?[^\t]*[^\n]*\n\+{3}[\s](/dev/null)?[^\t]*\t[^\n]*)#', $p_input, $t_matches, PREG_SET_ORDER);
+			preg_match_all('#diff[\s]*-r[\s]([^\s]*)[\s]*-r[\s]([^\s]*)[\s]([^\n]*)\n(Binary file[\s]([^\r\n\t\f\v]*)[\s]has changed|\-{3}[\s](/dev/null)?[^\t]*[^\n]*\n\+{3}[\s](/dev/null)?[^\t]*\t[^\n]*)#u', $p_input, $t_matches, PREG_SET_ORDER);
 
 			$t_commit['files'] = array();
 


### PR DESCRIPTION
A sample output from Mercurial raw file is as following:
```
diff -r c56b67cfe60d -r bb6504e6a338 01 中文資料夾/中文檔案.jpg
Binary file 01 中文資料夾/中文檔案.jpg has changed
```
The pattern is modified to allow spaces in the file path and Unicode character is accepted.