### PR TITLE
add space to ORDER BY clause

### DIFF
--- a/SourceCgit/SourceCgit.php
+++ b/SourceCgit/SourceCgit.php
@@ -175,7 +175,7 @@ class SourceCgitPlugin extends MantisSourceGitBasePlugin {
 		foreach( $t_branches as $t_branch ) {
 			$t_query = "SELECT parent FROM $t_changeset_table
 				WHERE repo_id=" . db_param() . ' AND branch=' . db_param() .
-				'ORDER BY timestamp ASC';
+				' ORDER BY timestamp ASC';
 			$t_result = db_query( $t_query, array( $p_repo->id, $t_branch ), 1 );
 
 			$t_commits = array( $t_branch );

--- a/SourceGithub/SourceGithub.php
+++ b/SourceGithub/SourceGithub.php
@@ -328,7 +328,7 @@ class SourceGithubPlugin extends MantisSourceGitBasePlugin {
 		foreach( $t_branches as $t_branch ) {
 			$t_query = "SELECT parent FROM $t_changeset_table
 				WHERE repo_id=" . db_param() . ' AND branch=' . db_param() .
-				'ORDER BY timestamp ASC';
+				' ORDER BY timestamp ASC';
 			$t_result = db_query( $t_query, array( $p_repo->id, $t_branch ), 1 );
 
 			$t_commits = array( $t_branch );

--- a/SourceGitphp/SourceGitphp.php
+++ b/SourceGitphp/SourceGitphp.php
@@ -195,7 +195,7 @@ class SourceGitphpPlugin extends MantisSourceGitBasePlugin {
 		foreach( $t_branches as $t_branch ) {
 			$t_query = "SELECT parent FROM $t_changeset_table
 				WHERE repo_id=" . db_param() . ' AND branch=' . db_param() .
-				'ORDER BY timestamp ASC';
+				' ORDER BY timestamp ASC';
 			$t_result = db_query_bound( $t_query, array( $p_repo->id, $t_branch ), 1 );
 
 			$t_commits = array( $t_branch );

--- a/SourceGitweb/SourceGitweb.php
+++ b/SourceGitweb/SourceGitweb.php
@@ -238,7 +238,7 @@ class SourceGitwebPlugin extends MantisSourceGitBasePlugin {
 		foreach( $t_branches as $t_branch ) {
 			$t_query = "SELECT parent FROM $t_changeset_table
 				WHERE repo_id=" . db_param() . ' AND branch=' . db_param() .
-				'ORDER BY timestamp ASC';
+				' ORDER BY timestamp ASC';
 			$t_result = db_query( $t_query, array( $p_repo->id, $t_branch ), 1 );
 
 			$t_commits = array( $t_branch );

--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -168,7 +168,7 @@ class SourceHgWebPlugin extends MantisSourcePlugin {
 		foreach( $t_branches as $t_branch ) {
 			$t_query = "SELECT parent FROM $t_changeset_table
 				WHERE repo_id=" . db_param() . ' AND branch=' . db_param() .
-				'ORDER BY timestamp ASC';
+				' ORDER BY timestamp ASC';
 			$t_result = db_query( $t_query, array( $p_repo->id, $t_branch ), 1 );
 
 			$t_commits = array( $t_branch );


### PR DESCRIPTION
without the space, you'll get this error: (Note the lack of space in the prepared query)
`APPLICATION ERROR #401
Database query failed. Error received from database was #1064: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'BY timestamp ASC LIMIT 1' at line 2 for the query: SELECT parent FROM mantis_plugin_Source_changeset_table
WHERE repo_id=? AND branch=?ORDER BY timestamp ASC.
Please use the "Back" button in your web browser to return to the previous page. There you can correct whatever problems were identified in this error or select another action. You can also click an option from the menu bar to go directly to a new section.`