### PR TITLE
Allow '#' at the start of commit message

### DIFF
--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -248,7 +248,9 @@ class SourceHgWebPlugin extends MantisSourcePlugin {
 				} else if( !isset( $t_commit['parent'] ) && preg_match( '@^# Parent +([a-f0-9]+)@', $t_line, $t_matches ) ) {
 					$t_parents[] = $t_matches[1];
 					$t_commit['parent'] = $t_matches[1];
-				}
+				} else if ( preg_match( '@^#\S.*@', $t_line ) )	{
++					$t_message[] = $t_line;
+ 				}
 			} else if( isset( $t_commit['revision'] ) ) {
 				if ( preg_match( '@^diff @', $t_line, $t_matches ) ) {
 					break;


### PR DESCRIPTION
Allow commit message to start a new line with # and not followed by a space.
In order to match #ID in the message.

For example, the following issue ID 58 can be matched now.
````
# HG changeset patch
# User Zipher <zipher@aa.com>
# Date 1500962954 -28800
# Node ID ef1876ac05842f491ebb9cff6dfc5d5ea6d4fff9
# Parent  8244ce736dde867b849edf8618d0b116312d4575
Add circuit diagram.
#58

diff -r 8244ce736dde -r ef1876ac0584 Panel.png
Binary file Panel.png has changed
````