### PR TITLE
Tweak call to plugin_push_current() in svn_call()

### DIFF
--- a/SourceSVN/SourceSVN.php
+++ b/SourceSVN/SourceSVN.php
@@ -330,9 +330,9 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 
 		# Get a full binary call, including configured parameters
 		if ( is_null( $s_call ) ) {
-			$s_call = self::svn_binary() . ' --non-interactive';
-
 			plugin_push_current( 'SourceSVN' );
+
+			$s_call = self::svn_binary() . ' --non-interactive';
 
 			if ( plugin_config_get( 'svnssl', false ) ) {
 				$s_call .= ' --trust-server-cert';


### PR DESCRIPTION
Move the call to plugin_push_current() to be before the first call
to svn_binary() to ensure that svn_binary()'s calls to
plugin_config_get() retrieve the options from SourceSVN's config
options rather than any plugin inheriting from SourceSVN.

Addresses issue seen in #241 