### PR TITLE
Importing an empty HgWeb repository causes lockup

### DIFF
--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -19,7 +19,7 @@ require_once( config_get( 'core_path' ) . 'url_api.php' );
 
 class SourceHgWebPlugin extends MantisSourcePlugin {
 
-	const PLUGIN_VERSION = '2.1.1';
+	const PLUGIN_VERSION = '2.1.2';
 	const FRAMEWORK_VERSION_REQUIRED = '2.0.0';
 
 	/**

--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -254,7 +254,10 @@ class SourceHgWebPlugin extends MantisSourcePlugin {
 		while( $i < count( $t_input ) && strpos( $t_input[$i++], '# HG changeset patch' ) === false );
 
 		# Check we haven't exhausted the input
-		if ( $i == count( $t_input )) return array (null, array());
+		if ( $i == count( $t_input )) {
+			echo 'repository may be empty?\n';
+			return array (null, array());
+		}
 
 		# Process changeset metadata
 		$t_commit = array();

--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -251,7 +251,10 @@ class SourceHgWebPlugin extends MantisSourcePlugin {
 		$i = 0;
 
 		# Skip changeset header
-		while( strpos( $t_input[$i++], '# HG changeset patch' ) === false );
+		while( $i < count( $t_input ) && strpos( $t_input[$i++], '# HG changeset patch' ) === false );
+
+		# Check we haven't exhausted the input
+		if ( $i == count( $t_input )) return array (null, array());
 
 		# Process changeset metadata
 		$t_commit = array();

--- a/SourceHgWeb/SourceHgWeb.php
+++ b/SourceHgWeb/SourceHgWeb.php
@@ -255,7 +255,7 @@ class SourceHgWebPlugin extends MantisSourcePlugin {
 
 		# Check we haven't exhausted the input
 		if ( $i == count( $t_input )) {
-			echo 'repository may be empty?\n';
+			echo "Unexpected HgWeb response (" . trim( $p_input ) . ") - repository may be empty.\n";
 			return array (null, array());
 		}
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ specification.
 
 ## [Unreleased 2.x]
 
+### Fixed
+
+- HgWeb: prevent lockup and display warning when importing empty repository
+  [#269](https://github.com/mantisbt-plugins/source-integration/pull/269)
+
+
 --------------------------------------------------------------------------------
 
 # Releases for MantisBT 2.x


### PR DESCRIPTION
When running an import using SourceHgWeb, if it runs on an empty Hg repository it would lockup and PHP CPU usage hits 100%. This is because the '#HG changeset patch' string is never found, and the script just locks in a while loop.