### PR TITLE
Update Gitlab integration readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ MantisBT version | Tags | Branch | Notes
    relevant plugin extension:
 
     * [SourceGithub](docs/CONFIGURING.SourceGithub.md)
+    * [SourceGitlab](SourceGitlab/README.md)
     * [SourceViewVC](docs/CONFIGURING.SourceViewVC.md)
     * [SourceSVN](docs/CONFIGURING.SourceSVN.md)
 

--- a/SourceGitlab/README.md
+++ b/SourceGitlab/README.md
@@ -7,11 +7,11 @@
 
 ## Gitlab setup
 
- - Login with an Owner (or Adminstrator) of a Project, go to "Projet settings", "Web hooks",
-   add a Push hook with Mantis url and Mantis Source Integration plugin "API Key":
-   http://mantis.server.intra/plugin.php?page=Source/checkin&api_key=abcdeb8129a4451a35f47881
- - Create a user with (at least) read access to the repository. For a public repository, any user would work.
-   Login with this user, go to "Profile settings", "Account", and copy the "Private token".
+ - Login with an Owner (or Adminstrator) of a Project, go to "Settings" -> "Integrations" and
+   add a Push hook to Web Hooks section with Mantis URL and Mantis Source Integration plugin "API Key":
+   `http://mantis.server.intra/plugin.php?page=Source/checkin&api_key=abcdeb8129a4451a35f47881`
+ - Go to your user Settings -> "Access Token" -> "Personal Access Tokens" and create a token with at least "api"
+   access. You will need it as "hub_app_secret" in Mantis configuration.
 
 ## Mantis repository setup
 
@@ -19,7 +19,7 @@
  - URL field is not used by the plugin.
  - Gitlab config fields are:
   - hub_root: root url of the Gitlab webserver, required to access Web API
-  - hub_repoid: id of the Gitlab projet, starting from 1 for the first created project (auto-filed if reponame is valid and readable for the user)
+  - hub_repoid: id of the Gitlab project. Should be auto-filed if reponame is valid and readable for the user.
   - hub_reponame: full name of the project in the form "group-namespace/project-name"
   - hub_app_secret: the "Private token" of a user with at least a read access to the project.
   - master_branch: use '*' or a list of branches to track

--- a/SourceGitlab/README.md
+++ b/SourceGitlab/README.md
@@ -7,10 +7,10 @@
 
 ## Gitlab setup
 
- - Login with an Owner (or Adminstrator) of a Project, go to "Settings" -> "Integrations" and
+ - Login with an Owner (or Administrator) of a Project, go to *Settings -> Integrations* and
    add a Push hook to Web Hooks section with Mantis URL and Mantis Source Integration plugin "API Key":
    `http://mantis.server.intra/plugin.php?page=Source/checkin&api_key=abcdeb8129a4451a35f47881`
- - Go to your user Settings -> "Access Token" -> "Personal Access Tokens" and create a token with at least "api"
+ - Go to your user *Settings -> Access Token -> Personal Access Tokens* and create a token with at least "api"
    access. You will need it as "hub_app_secret" in Mantis configuration.
 
 ## Mantis repository setup
@@ -19,7 +19,7 @@
  - URL field is not used by the plugin.
  - Gitlab config fields are:
   - hub_root: root url of the Gitlab webserver, required to access Web API
-  - hub_repoid: id of the Gitlab project. Should be auto-filed if reponame is valid and readable for the user.
+  - hub_repoid: id of the Gitlab project. Should be auto-filled if reponame is valid and readable for the user.
   - hub_reponame: full name of the project in the form "group-namespace/project-name"
   - hub_app_secret: the "Private token" of a user with at least a read access to the project.
   - master_branch: use '*' or a list of branches to track


### PR DESCRIPTION
Just set up Gitlab integration and found out that current data is out-of-date. Also there was no link to Gitlab setup from the main readme.

- Added link to Gitlab setup to main README file
- Actualized Gitlab setup steps