### PR TITLE
SVN: support svn:log revprop changes

### DIFF
--- a/Source/Source.API.php
+++ b/Source/Source.API.php
@@ -1039,14 +1039,24 @@ class SourceChangeset {
 			$t_params = array();
 
 			foreach( $t_bugs_added as $t_bug_id ) {
-				$t_query .= ( $t_count == 0 ? '' : ', ' ) .
-					'(' . db_param() . ', ' . db_param() . ')';
-				$t_params[] = $this->id;
-				$t_params[] = $t_bug_id;
-				$t_count++;
+				$t_params_2 = array();
+				$t_query_2 = "SELECT COUNT(*) AS b FROM $t_bug_table WHERE change_id=" . db_param() . " AND bug_id=" . db_param();
+				$t_params_2[] = $this->id;
+				$t_params_2[] = $t_bug_id;
+				$t_result = db_query( $t_query_2, $t_params_2 );
+				$t_row = db_fetch_array( $t_result );
+				if ($t_row['b'] < 1) {
+					$t_query .= ( $t_count == 0 ? '' : ', ' ) .
+						'(' . db_param() . ', ' . db_param() . ')';
+					$t_params[] = $this->id;
+					$t_params[] = $t_bug_id;
+					$t_count++;
+				}
 			}
 
-			db_query( $t_query, $t_params );
+			if ( substr( $t_query, -1 ) == ")" ) {
+				db_query( $t_query, $t_params );
+			}
 
 			foreach( $t_bugs_added as $t_bug_id ) {
 				plugin_history_log( $t_bug_id, 'changeset_attached', '',

--- a/Source/Source.API.php
+++ b/Source/Source.API.php
@@ -473,8 +473,8 @@ class SourceVCS {
 			foreach ( $t_callbacks as $t_callback => $t_object ) {
 				if ( is_subclass_of( $t_object, 'MantisSourcePlugin' ) &&
 					is_string( $t_object->type ) && !is_blank( $t_object->type ) ) {
-						$t_type = strtolower($t_object->type);
-						self::$cache[ $t_type ] = new SourceVCSWrapper( $t_object );
+					$t_type = strtolower($t_object->type);
+					self::$cache[ $t_type ] = new SourceVCSWrapper( $t_object );
 				}
 			}
 		}
@@ -914,7 +914,7 @@ class SourceChangeset {
 	 * @param string $p_author_email
 	 */
 	function __construct( $p_repo_id, $p_revision, $p_branch='', $p_timestamp='',
-		$p_author='', $p_message='', $p_user_id=0, $p_parent='', $p_ported='', $p_author_email='' ) {
+						  $p_author='', $p_message='', $p_user_id=0, $p_parent='', $p_ported='', $p_author_email='' ) {
 
 		$this->id				= 0;
 		$this->user_id			= $p_user_id;
@@ -1039,24 +1039,14 @@ class SourceChangeset {
 			$t_params = array();
 
 			foreach( $t_bugs_added as $t_bug_id ) {
-				$t_params_2 = array();
-				$t_query_2 = "SELECT COUNT(*) AS b FROM $t_bug_table WHERE change_id=" . db_param() . " AND bug_id=" . db_param();
-				$t_params_2[] = $this->id;
-				$t_params_2[] = $t_bug_id;
-				$t_result = db_query( $t_query_2, $t_params_2 );
-				$t_row = db_fetch_array( $t_result );
-				if ($t_row['b'] < 1) {
-					$t_query .= ( $t_count == 0 ? '' : ', ' ) .
-						'(' . db_param() . ', ' . db_param() . ')';
-					$t_params[] = $this->id;
-					$t_params[] = $t_bug_id;
-					$t_count++;
-				}
+				$t_query .= ( $t_count == 0 ? '' : ', ' ) .
+					'(' . db_param() . ', ' . db_param() . ')';
+				$t_params[] = $this->id;
+				$t_params[] = $t_bug_id;
+				$t_count++;
 			}
 
-			if ( substr( $t_query, -1 ) == ")" ) {
-				db_query( $t_query, $t_params );
-			}
+			db_query( $t_query, $t_params );
 
 			foreach( $t_bugs_added as $t_bug_id ) {
 				plugin_history_log( $t_bug_id, 'changeset_attached', '',
@@ -1624,7 +1614,7 @@ class SourceUser {
 				$this->new = false;
 			}
 
-		# handle loaded objects
+			# handle loaded objects
 		} else {
 			if ( is_blank( $this->username ) ) { # delete existing entry
 				$t_query = "DELETE FROM $t_user_table WHERE user_id=" . db_param();

--- a/Source/pages/checkin.php
+++ b/Source/pages/checkin.php
@@ -8,7 +8,7 @@ $t_valid = false;
 
 # Always allow the same machine to check-in
 if ( '127.0.0.1' == $t_address || '127.0.1.1' == $t_address
-     || 'localhost' == $t_address || '::1' == $t_address ) {
+	|| 'localhost' == $t_address || '::1' == $t_address ) {
 	$t_valid = true;
 }
 
@@ -61,9 +61,6 @@ if ( !$t_valid ) {
 # Let plugins try to intepret POST data before we do
 $t_predata = event_signal( 'EVENT_SOURCE_PRECOMMIT' );
 
-# Try to gracefully detect revprop changes flag
-$f_revprop = gpc_get_bool( 'revprop', false );
-
 # Expect plugin data in form of array( repo_name, data )
 if ( is_array( $t_predata ) && count( $t_predata ) == 2 ) {
 	$t_repo = $t_predata['repo'];
@@ -82,7 +79,7 @@ if ( is_null( $t_repo ) ) {
 $t_vcs = SourceVCS::repo( $t_repo );
 
 # Let the plugins handle commit data
-$t_changesets = $t_vcs->commit( $t_repo, $f_data, $f_revprop );
+$t_changesets = $t_vcs->commit( $t_repo, $f_data );
 
 # Changesets couldn't be loaded apparently
 if ( !is_array( $t_changesets ) ) {
@@ -95,4 +92,3 @@ if ( count( $t_changesets ) < 1 ) {
 }
 
 Source_Process_Changesets( $t_changesets );
-

--- a/Source/pages/checkin.php
+++ b/Source/pages/checkin.php
@@ -61,6 +61,9 @@ if ( !$t_valid ) {
 # Let plugins try to intepret POST data before we do
 $t_predata = event_signal( 'EVENT_SOURCE_PRECOMMIT' );
 
+# Try to gracefully detect revprop changes flag
+$f_revprop = gpc_get_bool( 'revprop', false );
+
 # Expect plugin data in form of array( repo_name, data )
 if ( is_array( $t_predata ) && count( $t_predata ) == 2 ) {
 	$t_repo = $t_predata['repo'];
@@ -79,7 +82,7 @@ if ( is_null( $t_repo ) ) {
 $t_vcs = SourceVCS::repo( $t_repo );
 
 # Let the plugins handle commit data
-$t_changesets = $t_vcs->commit( $t_repo, $f_data );
+$t_changesets = $t_vcs->commit( $t_repo, $f_data, $f_revprop );
 
 # Changesets couldn't be loaded apparently
 if ( !is_array( $t_changesets ) ) {

--- a/SourceSVN/SourceSVN.php
+++ b/SourceSVN/SourceSVN.php
@@ -250,21 +250,24 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 		}
 	}
 
-	public function commit( $p_repo, $p_data, $p_revprop = false ) {
+	public function commit( $p_repo, $p_data ) {
 		if ( preg_match( '/(\d+)/', $p_data, $p_matches ) ) {
+
+			// Detect if there is a svn:log revprop change, assume not
+			$t_revprop = gpc_get_bool( 'revprop', false );
 
 			$t_url = $p_repo->url;
 			$t_revision = $p_matches[1];
 			$t_svnlog_xml = $this->svn_run( "log -v $t_url -r$t_revision --xml", $p_repo );
 
-			if ( $p_revprop == false ) {
+			if ( $t_revprop == false ) {
 				if ( SourceChangeset::exists( $p_repo->id, $t_revision ) ) {
-					echo "Revision $t_revision already committed!\n";
+					echo sprintf( plugin_lang_get( 'revision_already_committed' ), $t_revision );
 					return null;
 				}
-            }
+			}
 
-			return $this->process_svn_log_xml( $p_repo, $t_svnlog_xml, $p_revprop );
+			return $this->process_svn_log_xml( $p_repo, $t_svnlog_xml, $t_revprop );
 		}
 	}
 
@@ -443,7 +446,7 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 	 * Parse the svn log output (with --xml option)
 	 * @param SourceRepo SVN repository object
 	 * @param string SVN log (XML formated)
-     * @param boolean REVPROP change flag
+	 * @param boolean REVPROP change flag
 	 * @return SourceChangeset[] Changesets for the provided input (empty on error)
 	 */
 	private function process_svn_log_xml( $p_repo, $p_svnlog_xml, $p_revprop = false ) {
@@ -533,8 +536,8 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 			// Save changeset and append to array
 			if( !is_null( $t_changeset) ) {
 				if( !is_blank( $t_changeset->branch ) ) {
-				    if( $p_revprop ) {
-				        echo "  REVPROP change detected.\n";
+					if( $p_revprop ) {
+						echo plugin_lang_get( 'revprop_detected' );
 						$t_existing_changeset = SourceChangeset::load_by_revision( $p_repo, $t_changeset->revision );
 						$t_changeset->id = $t_existing_changeset->id;
 						$t_changeset->user_id = $t_existing_changeset->user_id;
@@ -544,7 +547,7 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 						if( count( $t_old_bugs ) >= count( $t_new_bugs )) {
 							$t_changeset->__bugs = array_diff( $t_old_bugs, $t_new_bugs );
 						}
-				    }
+					}
 					$t_changeset->save();
 					$t_changesets[] = $t_changeset;
 				}

--- a/SourceSVN/SourceSVN.php
+++ b/SourceSVN/SourceSVN.php
@@ -250,19 +250,21 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 		}
 	}
 
-	public function commit( $p_repo, $p_data ) {
+	public function commit( $p_repo, $p_data, $p_revprop = false ) {
 		if ( preg_match( '/(\d+)/', $p_data, $p_matches ) ) {
 
 			$t_url = $p_repo->url;
 			$t_revision = $p_matches[1];
 			$t_svnlog_xml = $this->svn_run( "log -v $t_url -r$t_revision --xml", $p_repo );
 
-			if ( SourceChangeset::exists( $p_repo->id, $t_revision ) ) {
-				echo "Revision $t_revision already committed!\n";
-				return null;
-			}
+			if ( $p_revprop == false ) {
+				if ( SourceChangeset::exists( $p_repo->id, $t_revision ) ) {
+					echo "Revision $t_revision already committed!\n";
+					return null;
+				}
+            }
 
-			return $this->process_svn_log_xml( $p_repo, $t_svnlog_xml );
+			return $this->process_svn_log_xml( $p_repo, $t_svnlog_xml, $p_revprop );
 		}
 	}
 
@@ -441,9 +443,10 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 	 * Parse the svn log output (with --xml option)
 	 * @param SourceRepo SVN repository object
 	 * @param string SVN log (XML formated)
+     * @param boolean REVPROP change flag
 	 * @return SourceChangeset[] Changesets for the provided input (empty on error)
 	 */
-	private function process_svn_log_xml( $p_repo, $p_svnlog_xml ) {
+	private function process_svn_log_xml( $p_repo, $p_svnlog_xml, $p_revprop = false ) {
 		$t_changesets = array();
 		$t_changeset = null;
 		$t_comments = '';
@@ -530,6 +533,18 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 			// Save changeset and append to array
 			if( !is_null( $t_changeset) ) {
 				if( !is_blank( $t_changeset->branch ) ) {
+				    if( $p_revprop ) {
+				        echo "  REVPROP change detected.\n";
+						$t_existing_changeset = SourceChangeset::load_by_revision( $p_repo, $t_changeset->revision );
+						$t_changeset->id = $t_existing_changeset->id;
+						$t_changeset->user_id = $t_existing_changeset->user_id;
+						$t_changeset->files = $t_existing_changeset->files;
+						$t_old_bugs = array_unique( Source_Parse_Buglinks( $t_existing_changeset->message ));
+						$t_new_bugs = array_unique( Source_Parse_Buglinks( $t_changeset->message ));
+						if( count( $t_old_bugs ) >= count( $t_new_bugs )) {
+							$t_changeset->__bugs = array_diff( $t_old_bugs, $t_new_bugs );
+						}
+				    }
 					$t_changeset->save();
 					$t_changesets[] = $t_changeset;
 				}

--- a/SourceSVN/SourceSVN.php
+++ b/SourceSVN/SourceSVN.php
@@ -260,7 +260,7 @@ class SourceSVNPlugin extends MantisSourcePlugin {
 			$t_revision = $p_matches[1];
 			$t_svnlog_xml = $this->svn_run( "log -v $t_url -r$t_revision --xml", $p_repo );
 
-			if ( $t_revprop == false ) {
+			if ( !$t_revprop ) {
 				if ( SourceChangeset::exists( $p_repo->id, $t_revision ) ) {
 					echo sprintf( plugin_lang_get( 'revision_already_committed' ), $t_revision );
 					return null;

--- a/SourceSVN/lang/strings_english.txt
+++ b/SourceSVN/lang/strings_english.txt
@@ -26,3 +26,6 @@ $s_plugin_SourceSVN_winstart = 'SVN: Use Windows `start`<br/><span class="small"
 $s_plugin_SourceSVN_error_path_invalid = 'Path to Subversion binary is invalid, inaccessible or not a directory.';
 $s_plugin_SourceSVN_error_svn_run = 'Failed to execute Subversion.';
 $s_plugin_SourceSVN_error_svn_cmd = 'Subversion execution returned an error: "%1$s".';
+
+$s_plugin_SourceSVN_revision_already_committed = 'Revision %s already committed!';
+$s_plugin_SourceSVN_revprop_detected = '  SVN:LOG revision property change detected.';

--- a/SourceSVN/post-revprop-change.tmpl
+++ b/SourceSVN/post-revprop-change.tmpl
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Copyright (c) 2014 GGP Systems Limited
+# Licensed under the BSD (3-clause) license
+
+REPOS="$1"
+REV="$2"
+PROP="$4"
+
+if [ "$PROP" = 'svn:log' ]; then
+	URL="http://localhost/mantisbt/plugin.php?page=Source/checkin"
+	PROJECT="Repository Name"
+	API_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+	LOG_FILE=`mktemp /tmp/svn_${PROJECT}_${REV}_log.XXX`
+
+	CURL=/usr/bin/curl
+
+	${CURL} -d "repo_name=${PROJECT}" -d "data=${REV}" -d "revprop=TRUE" -d "api_key=${API_KEY}" ${URL} >> ${LOG_FILE}
+fi


### PR DESCRIPTION
Add rudimentary support for svn:log revprop changes to permit SCI to keep
repositories current when you have developers that don't always get commit
messages right first time. Doesn't deal with reopening "accidentally closed"
issues.