### PR TITLE
Cgit checkin typo fix

### DIFF
--- a/SourceCgit/SourceCgit.php
+++ b/SourceCgit/SourceCgit.php
@@ -143,7 +143,7 @@ class SourceCgitPlugin extends MantisSourceGitBasePlugin {
 		# i.e. DATA=`echo $INPUT | sed -e 's/ /+/g'`
 		list( , $t_commit_id, $t_branch ) = explode( ' ', $p_data );
 		list( , , $t_branch ) = explode( '/', $t_branch );
-		$master_branches = map( 'trim', explode( ',', $p_repo->info['master_branch']));
+		$master_branches = array_map( 'trim', explode( ',', $p_repo->info['master_branch']));
 		if (!in_array($t_branch,$master_branches) )
 		{
 				return;


### PR DESCRIPTION
Caused error: Call to undefined function map()