### PR TITLE
Plugin with support for linking to VisualSVN Server repo browser web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.buildpath
 *.project
 *.idea
+.vs
+.svn
+*.DotSettings.user

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ plugins:
   [ViewVC](http://www.viewvc.org/) web frontend installation.
 * **SourceWebSVN**: SVN repositories accessible via a
   [WebSVN](http://www.websvn.info/) web frontend installation.
+* **SourceVisualSVNServer**: SVN repositories hosted on a 
+  [VisualSVN Server](https://www.visualsvn.com/server/) installation,
+  with support for URL linking from MantisBT to VisualSVN Server's web view interface.
 
 Support for additional source control tools should be rather
 straightforward to implement due to the flexibility inherent in the
@@ -120,6 +123,7 @@ MantisBT version | Tags | Branch | Notes
     * [SourceGitlab](SourceGitlab/README.md)
     * [SourceViewVC](docs/CONFIGURING.SourceViewVC.md)
     * [SourceSVN](docs/CONFIGURING.SourceSVN.md)
+    * [SourceVisualSVNServer](docs/CONFIGURING.SourceVisualSVNServer.md)
 
 9. Once configured, click the "Return to Repository" link and click either
    the "Import Everything" or "Import Newest Data" button to perform initial

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ plugins:
   [WebSVN](http://www.websvn.info/) web frontend installation.
 * **SourceVisualSVNServer**: SVN repositories hosted on a 
   [VisualSVN Server](https://www.visualsvn.com/server/) installation,
-  with support for URL linking from MantisBT to VisualSVN Server's web view interface.
+  with support for URL linking from MantisBT to VisualSVN Server's built-in web frontend.
 
 Support for additional source control tools should be rather
 straightforward to implement due to the flexibility inherent in the

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ plugins:
 * **SourceSVN**: SVN repositories locally accessible by the SVN binaries.
 * **SourceViewVC**: SVN repositories accessible via a
   [ViewVC](http://www.viewvc.org/) web frontend installation.
-* **SourceWebSVN**: SVN repositories accessible via a
-  [WebSVN](http://www.websvn.info/) web frontend installation.
 * **SourceVisualSVNServer**: SVN repositories hosted on a 
   [VisualSVN Server](https://www.visualsvn.com/server/) installation,
   with support for URL linking from MantisBT to VisualSVN Server's built-in web frontend.
+* **SourceWebSVN**: SVN repositories accessible via a
+  [WebSVN](http://www.websvn.info/) web frontend installation.
 
 Support for additional source control tools should be rather
 straightforward to implement due to the flexibility inherent in the

--- a/SourceVisualSVNServer/LICENSE
+++ b/SourceVisualSVNServer/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2019 David Hopkins, FBR Ltd
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+

--- a/SourceVisualSVNServer/SourceVisualSVNServer.php
+++ b/SourceVisualSVNServer/SourceVisualSVNServer.php
@@ -66,27 +66,29 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 		}
 
 		# Only include port in final URL if it was present originally
-		$t_port = isset( $t_url['port'] ) ? ':' . $t_url['port'] : '';
-
-		return $t_url['scheme'] . '://' . $t_url['host'] . $t_port . '/!/#' . $t_repo_path;
+		$t_port = isset( $t_repo_url['port'] ) ? ':' . $t_repo_url['port'] : '';
+		
+		$t_url = $t_repo_url['scheme'] . '://' . $t_repo_url['host'] . $t_port . '/!/#' . $t_repo_path;
+		return $t_url;
 	}
 
 	public function url_repo( $p_repo, $p_changeset=null ) {
-		$t_repo_url = $this->url_base( $p_repo );
+		$t_url = $this->url_base( $p_repo );
 		
 		if ( !is_null( $p_changeset ) ) {
 			$t_revision = $p_changeset->revision;
-			$t_repo_url .= '/view/r' . urlencode($t_revision) . '/';
+			$t_url .= '/view/r' . urlencode($t_revision) . '/';
 		}
 
-		return $t_repo_url;
+		return $t_url;
 	}
 
 	public function url_changeset( $p_repo, $p_changeset ) {
 		$t_repo_url = $this->url_base( $p_repo );
 		$t_revision = $p_changeset->revision;
 
-		return $t_repo_url . '/commit/r' . urlencode($t_revision) + '/';
+		$t_url = $t_repo_url . '/commit/r' . urlencode($t_revision) . '/';
+		return $t_url;
 	}
 
 	public function url_file( $p_repo, $p_changeset, $p_file ) {
@@ -97,20 +99,24 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 		$t_revision = ($p_file->action == 'rm')
 					? $p_changeset->revision - 1
 					: $p_changeset->revision;
-		
-		return $t_repo_url . '/view/r' . urlencode($t_revision) . '/' . $p_file;
+
+		$t_url = $t_repo_url . '/view/r' . urlencode($t_revision) . $p_file->filename;
+				
+		return $t_url;
 	}
 
 	public function url_diff( $p_repo, $p_changeset, $p_file ) {
 		if ( $p_file->action == 'rm' || $p_file->action == 'add' ) {
-			return '';
+			# Return default no-link for add/remove change diffs
+			return parent::url_diff($p_repo, $p_changeset, $p_file);
 		}
 
 		# The web interface for VisualSVN Server displays file diffs as inline content 
 		# when viewing a particular commit.
 		# It doesn't have a specific page for single-file diffs, 
 		# at least as of v3.9.5, 2019-04-29
-		return url_changeset( $p_repo, $p_changeset );
+		$t_url = $this->url_changeset( $p_repo, $p_changeset );
+		return $t_url;
 	}
 
 	public function update_repo_form( $p_repo ) {

--- a/SourceVisualSVNServer/SourceVisualSVNServer.php
+++ b/SourceVisualSVNServer/SourceVisualSVNServer.php
@@ -1,0 +1,136 @@
+<?php
+
+# Copyright (c) 2019 David Hopkins, FBR Ltd
+# Copyright (c) 2015 John Bailey
+# Copyright (c) 2012 John Reese
+# Licensed under the MIT license
+
+if ( false === include_once( config_get( 'plugin_path' ) . 'SourceSVN/SourceSVN.php' ) ) {
+	return;
+}
+
+class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
+
+	const PLUGIN_VERSION = '2.0.2';
+	const FRAMEWORK_VERSION_REQUIRED = '2.0.0';
+	const SOURCESVN_VERSION_REQUIRED = '2.0.0';
+
+	public function register() {
+		$this->name = lang_get( 'plugin_SourceVisualSVNServer_title' );
+		$this->description = lang_get( 'plugin_SourceVisualSVNServer_description' );
+
+		$this->version = self::PLUGIN_VERSION;
+		$this->requires = array(
+			'MantisCore' => self::MANTIS_VERSION,
+			'Source' => self::FRAMEWORK_VERSION_REQUIRED,
+			'SourceSVN' => self::SOURCESVN_VERSION_REQUIRED,
+		);
+
+		$this->author = 'David Hopkins';
+		$this->contact = 'david.hopkins@fbr.com.au';
+		$this->url = 'https://github.com/mantisbt-plugins/source-integration';
+	}
+
+	public $type = 'VisualSVNServer';
+
+	public function show_type() {
+		return lang_get( 'plugin_SourceVisualSVNServer_type' );
+	}
+
+	public function get_visualsvnserver_url_prefix( $p_repo ) {
+		return isset( $p_repo->info['visualsvnserver_url_prefix'] )
+			? $p_repo->info['visualsvnserver_url_prefix']
+			: 'svn'; # Match VisualSVN Server default configuration
+	}
+
+	/**
+	 * Builds the VisualSVNServer URL base string
+	 * @param object $p_repo repository
+	 * @return string VisualSVNServer URL
+	 */
+	protected function url_base( $p_repo ) {
+		# VisualSVN Server web interface is always on the same host name
+		# as the HTTP(S)-served repositories, accessed via the /!/#reponame path
+		$t_repo_url = parse_url($p_repo->url);
+		$t_repo_path = $t_repo_url['path'];
+
+		$t_url_prefix = $this->get_visualsvnserver_url_prefix( $p_repo );
+
+		# Strip repo prefix (typically 'svn') from path, if present
+		if ( !empty( $t_url_prefix ) ) {
+			$t_prefix = '/' . $t_url_prefix . '/';
+			
+			if (substr($t_repo_path, 0, strlen($t_prefix)) == $t_prefix) {
+				$t_repo_path = substr($t_repo_path, strlen($t_prefix));
+			}
+		}
+
+		# Only include port in final URL if it was present originally
+		$t_port = isset( $t_url['port'] ) ? ':' . $t_url['port'] : '';
+
+		return $t_url['scheme'] . "://" . $t_url['host'] . $t_port . "/!/#" . $t_repo_path;
+	}
+
+	public function url_repo( $p_repo, $p_changeset=null ) {
+		$t_repo_url = url_base( $p_repo );
+
+		if ( !is_null( $p_changeset ) ) {
+			$t_repo_url .= '/view/r' . $p_changeset->revision . '/';
+		}
+
+		return $t_repo_url;
+	}
+
+	public function url_changeset( $p_repo, $p_changeset ) {
+		$t_rev = $p_changeset->revision;
+		$t_repo_url = url_base( $p_repo );
+
+		return $t_repo_url . '/commit/r' . $t_rev + '/';
+	}
+
+	public function url_file( $p_repo, $p_changeset, $p_file ) {
+		# if the file has been removed, it doesn't exist in current revision
+		# so we generate a link to (current revision - 1)
+		$t_revision = ($p_file->action == 'rm')
+					? $p_changeset->revision - 1
+					: $p_changeset->revision;
+		
+		$t_repo_url = url_base( $p_repo );
+
+		return $t_repo_url . '/view/r' . $t_revision . '/' . $p_file;
+	}
+
+	public function url_diff( $p_repo, $p_changeset, $p_file ) {
+		if ( $p_file->action == 'rm' || $p_file->action == 'add' ) {
+			return '';
+		}
+
+		# The web interface for VisualSVN Server displays file diffs as inline content 
+		# when viewing a particular commit.
+		# It doesn't have a specific page for single-file diffs, 
+		# at least as of v3.9.5, 2019-04-29
+		return url_changeset( $p_repo, $p_changeset );
+	}
+
+	public function update_repo_form( $p_repo ) {
+		$t_url_prefix   = $this->get_VisualSVNServer_url_prefix( $p_repo );
+
+?>
+<tr>
+	<td class="category"><?php echo lang_get( 'plugin_SourceVisualSVNServer_visualsvnserver_url_prefix' ) ?></td>
+	<td>
+		<input type="text" name="visualsvnserver_url_prefix" maxlength="250" size="40" value="<?php echo string_attribute( $t_url_prefix ) ?>"/>
+	</td>
+</tr>
+<?php
+
+		return parent::update_repo_form( $p_repo );
+	}
+
+	public function update_repo( $p_repo ) {
+
+		$p_repo->info['visualsvnserver_url_prefix'] = gpc_get_string( 'visualsvnserver_url_prefix' );
+
+		return parent::update_repo( $p_repo );
+	}
+}

--- a/SourceVisualSVNServer/SourceVisualSVNServer.php
+++ b/SourceVisualSVNServer/SourceVisualSVNServer.php
@@ -72,31 +72,32 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 	}
 
 	public function url_repo( $p_repo, $p_changeset=null ) {
-		$t_repo_url = url_base( $p_repo );
-
+		$t_repo_url = $this->url_base( $p_repo );
+		
 		if ( !is_null( $p_changeset ) ) {
-			$t_repo_url .= '/view/r' . urlencode($p_changeset->revision) . '/';
+			$t_revision = $p_changeset->revision;
+			$t_repo_url .= '/view/r' . urlencode($t_revision) . '/';
 		}
 
 		return $t_repo_url;
 	}
 
 	public function url_changeset( $p_repo, $p_changeset ) {
-		$t_rev = $p_changeset->revision;
-		$t_repo_url = url_base( $p_repo );
+		$t_repo_url = $this->url_base( $p_repo );
+		$t_revision = $p_changeset->revision;
 
-		return $t_repo_url . '/commit/r' . urlencode($t_rev) + '/';
+		return $t_repo_url . '/commit/r' . urlencode($t_revision) + '/';
 	}
 
 	public function url_file( $p_repo, $p_changeset, $p_file ) {
+		$t_repo_url = $this->url_base( $p_repo );
+
 		# if the file has been removed, it doesn't exist in current revision
 		# so we generate a link to (current revision - 1)
 		$t_revision = ($p_file->action == 'rm')
 					? $p_changeset->revision - 1
 					: $p_changeset->revision;
 		
-		$t_repo_url = url_base( $p_repo );
-
 		return $t_repo_url . '/view/r' . urlencode($t_revision) . '/' . $p_file;
 	}
 

--- a/SourceVisualSVNServer/SourceVisualSVNServer.php
+++ b/SourceVisualSVNServer/SourceVisualSVNServer.php
@@ -16,8 +16,8 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 	const SOURCESVN_VERSION_REQUIRED = '2.0.0';
 
 	public function register() {
-		$this->name = lang_get( 'plugin_SourceVisualSVNServer_title' );
-		$this->description = lang_get( 'plugin_SourceVisualSVNServer_description' );
+		$this->name = plugin_lang_get( 'title' );
+		$this->description = plugin_lang_get( 'description' );
 
 		$this->version = self::PLUGIN_VERSION;
 		$this->requires = array(
@@ -34,7 +34,7 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 	public $type = 'vsvns';
 
 	public function show_type() {
-		return lang_get( 'plugin_SourceVisualSVNServer_vsvns' );
+		return plugin_lang_get( 'vsvns' );
 	}
 
 	public function get_visualsvnserver_url_prefix( $p_repo ) {
@@ -75,7 +75,7 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 		$t_repo_url = url_base( $p_repo );
 
 		if ( !is_null( $p_changeset ) ) {
-			$t_repo_url .= '/view/r' . $p_changeset->revision . '/';
+			$t_repo_url .= '/view/r' . urlencode($p_changeset->revision) . '/';
 		}
 
 		return $t_repo_url;
@@ -85,7 +85,7 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 		$t_rev = $p_changeset->revision;
 		$t_repo_url = url_base( $p_repo );
 
-		return $t_repo_url . '/commit/r' . $t_rev + '/';
+		return $t_repo_url . '/commit/r' . urlencode($t_rev) + '/';
 	}
 
 	public function url_file( $p_repo, $p_changeset, $p_file ) {
@@ -97,7 +97,7 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 		
 		$t_repo_url = url_base( $p_repo );
 
-		return $t_repo_url . '/view/r' . $t_revision . '/' . $p_file;
+		return $t_repo_url . '/view/r' . urlencode($t_revision) . '/' . $p_file;
 	}
 
 	public function url_diff( $p_repo, $p_changeset, $p_file ) {
@@ -113,11 +113,11 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 	}
 
 	public function update_repo_form( $p_repo ) {
-		$t_url_prefix   = $this->get_VisualSVNServer_url_prefix( $p_repo );
+		$t_url_prefix   = $this->get_visualsvnserver_url_prefix( $p_repo );
 
 ?>
 <tr>
-	<td class="category"><?php echo lang_get( 'plugin_SourceVisualSVNServer_visualsvnserver_url_prefix' ) ?></td>
+	<td class="category"><?php echo plugin_lang_get( 'url_prefix' ) ?></td>
 	<td>
 		<input type="text" name="visualsvnserver_url_prefix" maxlength="250" size="40" value="<?php echo string_attribute( $t_url_prefix ) ?>"/>
 	</td>

--- a/SourceVisualSVNServer/SourceVisualSVNServer.php
+++ b/SourceVisualSVNServer/SourceVisualSVNServer.php
@@ -117,7 +117,7 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 
 ?>
 <tr>
-	<td class="category"><?php echo plugin_lang_get( 'url_prefix' ) ?></td>
+	<td class="category"><?php echo plugin_lang_get( 'visualsvnserver_url_prefix' ) ?></td>
 	<td>
 		<input type="text" name="visualsvnserver_url_prefix" maxlength="250" size="40" value="<?php echo string_attribute( $t_url_prefix ) ?>"/>
 	</td>

--- a/SourceVisualSVNServer/SourceVisualSVNServer.php
+++ b/SourceVisualSVNServer/SourceVisualSVNServer.php
@@ -51,30 +51,30 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 	protected function url_base( $p_repo ) {
 		# VisualSVN Server web interface is always on the same host name
 		# as the HTTP(S)-served repositories, accessed via the /!/#reponame path
-		$t_repo_url = parse_url($p_repo->url);
+		$t_repo_url = parse_url( $p_repo->url );
 		$t_repo_path = $t_repo_url['path'];
 
 		$t_url_prefix = $this->get_visualsvnserver_url_prefix( $p_repo );
 
 		# Strip repo prefix (typically '/svn/') from path
-		$t_prefix = empty( $t_url_prefix ) ? '/' : '/' . urlencode($t_url_prefix) . '/';
-		if (substr($t_repo_path, 0, strlen($t_prefix)) == $t_prefix) {
-			$t_repo_path = substr($t_repo_path, strlen($t_prefix));
+		$t_prefix = empty( $t_url_prefix ) ? '/' : '/' . urlencode( $t_url_prefix ) . '/';
+		if( substr( $t_repo_path, 0, strlen( $t_prefix ) ) == $t_prefix ) {
+			$t_repo_path = substr( $t_repo_path, strlen( $t_prefix ) );
 		}
 
 		# Only include port in final URL if it was present originally
 		$t_port = isset( $t_repo_url['port'] ) ? ':' . $t_repo_url['port'] : '';
-		
+
 		$t_url = $t_repo_url['scheme'] . '://' . $t_repo_url['host'] . $t_port . '/!/#' . $t_repo_path;
 		return $t_url;
 	}
 
-	public function url_repo( $p_repo, $p_changeset=null ) {
+	public function url_repo( $p_repo, $p_changeset = null ) {
 		$t_url = $this->url_base( $p_repo );
-		
-		if ( !is_null( $p_changeset ) ) {
+
+		if( !is_null( $p_changeset ) ) {
 			$t_revision = $p_changeset->revision;
-			$t_url .= '/view/r' . urlencode($t_revision) . '/';
+			$t_url .= '/view/r' . urlencode( $t_revision ) . '/';
 		}
 
 		return $t_url;
@@ -84,7 +84,7 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 		$t_repo_url = $this->url_base( $p_repo );
 		$t_revision = $p_changeset->revision;
 
-		$t_url = $t_repo_url . '/commit/r' . urlencode($t_revision) . '/';
+		$t_url = $t_repo_url . '/commit/r' . urlencode( $t_revision ) . '/';
 		return $t_url;
 	}
 
@@ -93,19 +93,19 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 
 		# if the file has been removed, it doesn't exist in current revision
 		# so we generate a link to (current revision - 1)
-		$t_revision = ($p_file->action == 'rm')
-					? $p_changeset->revision - 1
-					: $p_changeset->revision;
+		$t_revision = ( $p_file->action == 'rm' )
+			? $p_changeset->revision - 1
+			: $p_changeset->revision;
 
-		$t_url = $t_repo_url . '/view/r' . urlencode($t_revision) . $p_file->filename;
-				
+		$t_url = $t_repo_url . '/view/r' . urlencode( $t_revision ) . $p_file->filename;
+
 		return $t_url;
 	}
 
 	public function url_diff( $p_repo, $p_changeset, $p_file ) {
-		if ( $p_file->action == 'rm' || $p_file->action == 'add' ) {
+		if( $p_file->action == 'rm' || $p_file->action == 'add' ) {
 			# Return default no-link for add/remove change diffs
-			return parent::url_diff($p_repo, $p_changeset, $p_file);
+			return parent::url_diff( $p_repo, $p_changeset, $p_file );
 		}
 
 		# The web interface for VisualSVN Server displays file diffs as inline content 
@@ -117,22 +117,21 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 	}
 
 	public function update_repo_form( $p_repo ) {
-		$t_url_prefix   = $this->get_visualsvnserver_url_prefix( $p_repo );
-
+		$t_url_prefix = $this->get_visualsvnserver_url_prefix( $p_repo );
 ?>
 <tr>
 	<td class="category"><?php echo plugin_lang_get( 'visualsvnserver_url_prefix' ) ?></td>
 	<td>
-		<input type="text" name="visualsvnserver_url_prefix" maxlength="250" size="40" value="<?php echo string_attribute( $t_url_prefix ) ?>"/>
+		<input type="text" name="visualsvnserver_url_prefix" maxlength="250" size="40"
+			   value="<?php echo string_attribute( $t_url_prefix ) ?>"
+		/>
 	</td>
 </tr>
 <?php
-
 		return parent::update_repo_form( $p_repo );
 	}
 
 	public function update_repo( $p_repo ) {
-
 		$p_repo->info['visualsvnserver_url_prefix'] = gpc_get_string( 'visualsvnserver_url_prefix' );
 
 		return parent::update_repo( $p_repo );

--- a/SourceVisualSVNServer/SourceVisualSVNServer.php
+++ b/SourceVisualSVNServer/SourceVisualSVNServer.php
@@ -56,13 +56,10 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 
 		$t_url_prefix = $this->get_visualsvnserver_url_prefix( $p_repo );
 
-		# Strip repo prefix (typically 'svn') from path, if present
-		if ( !empty( $t_url_prefix ) ) {
-			$t_prefix = '/' . $t_url_prefix . '/';
-			
-			if (substr($t_repo_path, 0, strlen($t_prefix)) == $t_prefix) {
-				$t_repo_path = substr($t_repo_path, strlen($t_prefix));
-			}
+		# Strip repo prefix (typically '/svn/') from path
+		$t_prefix = empty( $t_url_prefix ) ? '/' : '/' . urlencode($t_url_prefix) . '/';
+		if (substr($t_repo_path, 0, strlen($t_prefix)) == $t_prefix) {
+			$t_repo_path = substr($t_repo_path, strlen($t_prefix));
 		}
 
 		# Only include port in final URL if it was present originally

--- a/SourceVisualSVNServer/SourceVisualSVNServer.php
+++ b/SourceVisualSVNServer/SourceVisualSVNServer.php
@@ -31,10 +31,10 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 		$this->url = 'https://github.com/mantisbt-plugins/source-integration';
 	}
 
-	public $type = 'VisualSVNServer';
+	public $type = 'vsvns';
 
 	public function show_type() {
-		return lang_get( 'plugin_SourceVisualSVNServer_type' );
+		return lang_get( 'plugin_SourceVisualSVNServer_vsvns' );
 	}
 
 	public function get_visualsvnserver_url_prefix( $p_repo ) {
@@ -68,7 +68,7 @@ class SourceVisualSVNServerPlugin extends SourceSVNPlugin {
 		# Only include port in final URL if it was present originally
 		$t_port = isset( $t_url['port'] ) ? ':' . $t_url['port'] : '';
 
-		return $t_url['scheme'] . "://" . $t_url['host'] . $t_port . "/!/#" . $t_repo_path;
+		return $t_url['scheme'] . '://' . $t_url['host'] . $t_port . '/!/#' . $t_repo_path;
 	}
 
 	public function url_repo( $p_repo, $p_changeset=null ) {

--- a/SourceVisualSVNServer/lang/strings_english.txt
+++ b/SourceVisualSVNServer/lang/strings_english.txt
@@ -4,9 +4,8 @@
 # Licensed under the MIT license
 
 $s_plugin_SourceVisualSVNServer_ = '';
+$s_plugin_SourceVisualSVNServer_vsvns = 'VisualSVN Server';
 $s_plugin_SourceVisualSVNServer_title = 'Source Subversion / VisualSVN Server Integration';
-$s_plugin_SourceVisualSVNServer_description = 'Adds Subversion integration to the Source plugin framework with browse and view hyperlinks to the VisualSVN Server web interface.';
+$s_plugin_SourceVisualSVNServer_description = 'Adds Subversion integration to the Source plugin framework with hyperlinks to the VisualSVN Server web interface.';
 
-$s_plugin_SourceVisualSVNServer_type = 'VisualSVN Server';
-
-$s_plugin_SourceVisualSVNServer_visualsvnserver_url_prefix = 'VisualSVN Server repository URL prefix<br/><span class="small">(Default 'svn')</span>';
+$s_plugin_SourceVisualSVNServer_visualsvnserver_url_prefix = 'VisualSVN Server repository URL prefix<br/><span class="small">(Default "svn")</span>';

--- a/SourceVisualSVNServer/lang/strings_english.txt
+++ b/SourceVisualSVNServer/lang/strings_english.txt
@@ -1,0 +1,12 @@
+<?php
+# Copyright (c) 2019 David Hopkins, FBR Ltd
+# Copyright (c) 2012 John Reese
+# Licensed under the MIT license
+
+$s_plugin_SourceVisualSVNServer_ = '';
+$s_plugin_SourceVisualSVNServer_title = 'Source Subversion / VisualSVN Server Integration';
+$s_plugin_SourceVisualSVNServer_description = 'Adds Subversion integration to the Source plugin framework with browse and view hyperlinks to the VisualSVN Server web interface.';
+
+$s_plugin_SourceVisualSVNServer_type = 'VisualSVN Server';
+
+$s_plugin_SourceVisualSVNServer_visualsvnserver_url_prefix = 'VisualSVN Server repository URL prefix<br/><span class="small">(Default 'svn')</span>';

--- a/SourceVisualSVNServer/lang/strings_english.txt
+++ b/SourceVisualSVNServer/lang/strings_english.txt
@@ -10,8 +10,8 @@ $s_plugin_SourceVisualSVNServer_description = 'Adds Subversion integration to th
 
 $s_plugin_SourceVisualSVNServer_visualsvnserver_url_prefix = 'VisualSVN Server repository URL prefix<br/><span class="small">(Default "svn")</span>';
 
-$s_plugin_SourceVisualSVNServer_svn_username = 'SVN Username';
-$s_plugin_SourceVisualSVNServer_svn_password = 'SVN Password';
+$s_plugin_SourceVisualSVNServer_svn_username = 'SVN Username<br/><span class="small">(Ignored under Integrated Windows Authentication)</span>';
+$s_plugin_SourceVisualSVNServer_svn_password = 'SVN Password<br/><span class="small">(Ignored under Integrated Windows Authentication)</span>';
 $s_plugin_SourceVisualSVNServer_standard_repo = 'Standard Repository<br/><span class="small">(trunk/branches/tags)</span>';
 $s_plugin_SourceVisualSVNServer_trunk_path = 'Trunk Path<br/><span class="small">(Non-standard repository)</span>';
 $s_plugin_SourceVisualSVNServer_branch_path = 'Branch Path<br/><span class="small">(Non-standard repository)</span>';

--- a/SourceVisualSVNServer/lang/strings_english.txt
+++ b/SourceVisualSVNServer/lang/strings_english.txt
@@ -5,7 +5,29 @@
 
 $s_plugin_SourceVisualSVNServer_ = '';
 $s_plugin_SourceVisualSVNServer_vsvns = 'VisualSVN Server';
-$s_plugin_SourceVisualSVNServer_title = 'Source Subversion / VisualSVN Server Integration';
-$s_plugin_SourceVisualSVNServer_description = 'Adds Subversion integration to the Source plugin framework with hyperlinks to the VisualSVN Server web interface.';
+$s_plugin_SourceVisualSVNServer_title = 'Source VisualSVN Server Integration';
+$s_plugin_SourceVisualSVNServer_description = 'Adds Subversion integration to the Source plugin framework, with hyperlinks to the VisualSVN Server web interface.';
 
 $s_plugin_SourceVisualSVNServer_visualsvnserver_url_prefix = 'VisualSVN Server repository URL prefix<br/><span class="small">(Default "svn")</span>';
+
+$s_plugin_SourceVisualSVNServer_svn_username = 'SVN Username';
+$s_plugin_SourceVisualSVNServer_svn_password = 'SVN Password';
+$s_plugin_SourceVisualSVNServer_standard_repo = 'Standard Repository<br/><span class="small">(trunk/branches/tags)</span>';
+$s_plugin_SourceVisualSVNServer_trunk_path = 'Trunk Path<br/><span class="small">(Non-standard repository)</span>';
+$s_plugin_SourceVisualSVNServer_branch_path = 'Branch Path<br/><span class="small">(Non-standard repository)</span>';
+$s_plugin_SourceVisualSVNServer_tag_path = 'Tag Path<br/><span class="small">(Non-standard repository)</span>';
+$s_plugin_SourceVisualSVNServer_ignore_paths = 'Ignore Other Paths<br/><span class="small">(Non-standard repository)</span>';
+
+$s_plugin_SourceVisualSVNServer_configuration = 'Configuration';
+$s_plugin_SourceVisualSVNServer_update = 'Configuration';
+$s_plugin_SourceVisualSVNServer_svnpath = 'SVN: Path to binary';
+$s_plugin_SourceVisualSVNServer_svnargs = 'SVN: Command arguments';
+$s_plugin_SourceVisualSVNServer_svnssl = 'SVN: Trust All SSL Certs<br/><span class="small">(Requires Subversion 1.6 or newer)</span>';
+$s_plugin_SourceVisualSVNServer_winstart = 'SVN: Use Windows `start`<br/><span class="small">(Requires a configured path to binary)</span>';
+
+$s_plugin_SourceVisualSVNServer_error_path_invalid = 'Path to Subversion binary is invalid, inaccessible or not a directory.';
+$s_plugin_SourceVisualSVNServer_error_svn_run = 'Failed to execute Subversion.';
+$s_plugin_SourceVisualSVNServer_error_svn_cmd = 'Subversion execution returned an error: "%1$s".';
+
+$s_plugin_SourceVisualSVNServer_revision_already_committed = 'Revision %s already committed!';
+$s_plugin_SourceVisualSVNServer_revprop_detected = '  SVN:LOG revision property change detected.';

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ specification.
 
 ### Added
 
+- Support for VisualSVN Server, thanks to David Hopkins, FBR Ltd
+  [#313](https://github.com/mantisbt-plugins/source-integration/pull/313)
 - Default primary branch can be configured for git-based repositories 
   [#308](https://github.com/mantisbt-plugins/source-integration/issues/308)
 

--- a/docs/CONFIGURING.SourceVisualSVNServer.md
+++ b/docs/CONFIGURING.SourceVisualSVNServer.md
@@ -17,7 +17,7 @@ Ensure that all of the following plugins are installed:
 * **SourceVisualSVNServer**
 
 See the [README](../README.md#installation) for overall instructions
-with regard to installing SourceIntegration plugins.
+with regards to installing SourceIntegration plugins.
 
 ## Configuration of SVN
 

--- a/docs/CONFIGURING.SourceVisualSVNServer.md
+++ b/docs/CONFIGURING.SourceVisualSVNServer.md
@@ -1,0 +1,50 @@
+# SourceVisualSVNServer Configuration
+
+## Description
+
+The **SourceVisualSVNServer** extension plugin adds support for 
+adding links from MantisBT to the VisualSVN Server web interface,
+in addition to the basic **SourceSVN** features.
+
+## Requirements
+
+The **SourceVisualSVNServer** plugin requires Mantis 1.2.x. See the
+[README](../README.md#requirements) for further information.
+
+Ensure that all of the following plugins are installed:
+* **Source**
+* **SourceSVN**
+* **SourceVisualSVNServer**
+
+See the [README](../README.md#installation) for overall instructions
+with regard to installing SourceIntegration plugins.
+
+## Configuration of SVN
+
+See [SourceSVN configuration](CONFIGURING.SourceSVN.md#configuration-of-the-plugin).
+
+## Configuration of a Repository
+
+1. Click the *Repositories* link in the navigation bar.
+
+2. In the *Create Repository* section:
+
+   - Enter the repository name in the *Name* text field.
+   - Select *VisualSVN Server* from the *Type* pop-up menu.
+   - Click the *Create Repository* button.
+
+3. This will take you to the *Update Repository* page where you'll need to fill 
+   in all the details for the repository:
+
+   - The *Name* field should be pre-populated with the name you entered in Step 2a above.
+   - Paste in the SVN repository's URL in the *URL* field 
+     (e.g. `https://localhost.localdomain/svn/myrepo`).
+   - Configure the [standard SVN repository settings](CONFIGURING.SourceSVN.md#configuration-of-a-repository).
+   - If necessary, update the repository URL path prefix to match the configuration of the VisualSVN Server (default `svn`).
+     The plugin uses this prefix to locate the corresponding web interface URLs for the repository.
+   - Click the *Update Repository* button.
+
+4. Click the *Import Everything* button to test connectivity and perform an 
+   initial import of the repository changesets.
+
+   **Note:** This may take a long time or even fail for large repositories.


### PR DESCRIPTION
I made a plugin that adds file and diff link button support for linking to the built-in web front-end for [VisualSVN Server](https://www.visualsvn.com/server/).

I have permission from my employer to contribute this plugin back into the source-integration project under the existing project MIT licence.

I'm not very experienced with Git or Github, so I'm not sure how I can (or if I should) exclude the documentation changes and sample scripts included in the 53a72cf commit, which are the same as the contents of PR #311.