### PR TITLE
Support to open websvn links within an iframe if IFramed plugin is installed

### DIFF
--- a/SourceWebSVN/SourceWebSVN.php
+++ b/SourceWebSVN/SourceWebSVN.php
@@ -115,7 +115,13 @@ class SourceWebSVNPlugin extends SourceSVNPlugin {
 			$p_opts['repname'] = $t_name;
 		}
 
-		return $t_url . '?' . http_build_query( $p_opts );
+		$t_url .= ( '?' . http_build_query( $p_opts ) );
+
+		if ( plugin_is_installed( 'IFramed' ) ) {
+			$t_url = plugin_page( 'main', false, 'IFramed' ) . '&title=WebSVN&usemime=1&url=' . urlencode($t_url);
+		}
+		
+		return $t_url;
 	}
 
 	public function url_repo( $p_repo, $p_changeset=null ) {

--- a/SourceWebSVN/SourceWebSVN.php
+++ b/SourceWebSVN/SourceWebSVN.php
@@ -118,7 +118,7 @@ class SourceWebSVNPlugin extends SourceSVNPlugin {
 		$t_url .= ( '?' . http_build_query( $p_opts ) );
 
 		if ( plugin_is_installed( 'IFramed' ) ) {
-			$t_url = plugin_page( 'main', false, 'IFramed' ) . '&title=WebSVN&usemime=1&url=' . urlencode($t_url);
+			$t_url = plugin_page( 'main', false, 'IFramed' ) . '&title=WebSVN&usemime=1&url=' . urlencode( $t_url );
 		}
 		
 		return $t_url;


### PR DESCRIPTION
Support to open websvn links within the mantisbt ui in an iframe, if the IFramed plugin is installed.

This of course would mean adjusting Content-Security-Policy header frame-src in mantisbt config (example in IFramed readme file).  And possibly, require a server config to handle some url encoding issue with the `&amp` when going to file details page from diff, in Apache I used:

`RewriteCond %{QUERY_STRING} ^repname=(.*)(&amp;)path=(.*)(&amp;)(.*)$`
`RewriteRule ^(.*)$ https://my.domain.com/websvn/filedetails.php?repname=%1&path=%3&%5 [N]`

![websvn-iframe](https://user-images.githubusercontent.com/48744816/63316417-d09c2b00-c2dc-11e9-8216-5fe6bf80878f.png)
