### PR TITLE
Various GitLab improvements (files, better retrieval of trees, import_limit, faster overview, regex for filtering branches, ...)

### DIFF
--- a/Source/MantisSourceGitBasePlugin.class.php
+++ b/Source/MantisSourceGitBasePlugin.class.php
@@ -46,6 +46,7 @@ abstract class MantisSourceGitBasePlugin extends MantisSourcePlugin
 	 * Error constants
 	 */
 	const ERROR_INVALID_BRANCH = 'invalid_branch';
+	const ERROR_INVALID_BRANCH_REGEXP = 'invalid_branch_regexp';
 
 	/**
 	 * Define plugin's Error strings
@@ -54,6 +55,7 @@ abstract class MantisSourceGitBasePlugin extends MantisSourcePlugin
 	public function errors() {
 		$t_errors_list = array(
 			self::ERROR_INVALID_BRANCH,
+			self::ERROR_INVALID_BRANCH_REGEXP,
 		);
 
 		foreach( $t_errors_list as $t_error ) {
@@ -87,14 +89,23 @@ abstract class MantisSourceGitBasePlugin extends MantisSourcePlugin
 	}
 
 	/**
-	 * Validates a comma-delimited list of git branches.
+	 * Validates regexp or a comma-delimited list of git branches.
 	 * Triggers an ERROR_INVALID_BRANCH if one of the branches is invalid
-	 * @param string $p_list Comma-delimited list of branch names (or '*')
+	 * Triggers an ERROR_INVALID_BRANCH_REGEXP if regexp has an error
+	 * @param string $p_list Comma-delimited list of branch names (or regexp or '*')
 	 * @return void
 	 */
 	protected function validate_branch_list( $p_list )
 	{
 		if( $p_list == '*' ) {
+			return;
+		}
+
+		if ( preg_match( '@^/.*/$@', trim( $p_list ) ) ) {
+			if (@preg_match( $p_list, null ) === false ) {
+				error_parameters( $p_list );
+				plugin_error( self::ERROR_INVALID_BRANCH_REGEXP );
+			}
 			return;
 		}
 

--- a/Source/Source.API.php
+++ b/Source/Source.API.php
@@ -679,11 +679,16 @@ class SourceRepo {
 		$t_stats['changesets'] = db_result( db_query( $t_query, array( $this->id ) ) );
 
 		if ( $p_all ) {
-			$t_query = "SELECT COUNT(DISTINCT filename) FROM $t_file_table AS f
+			# files can be very slow
+			if ( plugin_config_get( 'enable_file_stats' ) ) {
+				$t_query = "SELECT COUNT(DISTINCT filename) FROM $t_file_table AS f
 						JOIN $t_changeset_table AS c
 						ON c.id=f.change_id
 						WHERE c.repo_id=" . db_param();
-			$t_stats['files'] = db_result( db_query( $t_query, array( $this->id ) ) );
+				$t_stats['files'] = db_result( db_query_bound( $t_query, array( $this->id ) ) );
+			} else { 
+				$t_stats['files'] = -1;
+			}
 
 			$t_query = "SELECT COUNT(DISTINCT bug_id) FROM $t_bug_table AS b
 						JOIN $t_changeset_table AS c

--- a/Source/Source.php
+++ b/Source/Source.php
@@ -70,6 +70,7 @@ class SourcePlugin extends MantisSourceBase {
 			'enable_resolving'	=> OFF,
 			'enable_message'	=> OFF,
 			'enable_product_matrix' => OFF,
+			'enable_file_stats'	=> OFF,
 
 			'buglink_regex_1'	=> '/(?:bugs?|issues?|reports?)+\s*:?\s+(?:#(?:\d+)[,\.\s]*)+/i',
 			'buglink_regex_2'	=> '/#?(\d+)/',

--- a/Source/lang/strings_catalan.txt
+++ b/Source/lang/strings_catalan.txt
@@ -108,6 +108,7 @@ $s_plugin_Source_enable_resolving = 'Resoldre incidèncias arreglades';
 $s_plugin_Source_enable_message = 'Missatge d\'incidència resolta';
 $s_plugin_Source_enable_porting = 'Estat de portabilitat';
 $s_plugin_Source_enable_product_matrix = 'Integració de la Matriu de Producte';
+$s_plugin_Source_enable_file_stats = 'Estadístiques de fitxers <span class="small" (pot ser lent als dipòsits grans)</span>";
 
 $s_plugin_Source_branch_mapping = 'Mapejos de branques';
 $s_plugin_Source_mapping_update = 'Actualitzar mapejats';

--- a/Source/lang/strings_english.txt
+++ b/Source/lang/strings_english.txt
@@ -113,6 +113,7 @@ $s_plugin_Source_enable_resolving = 'Resolve Fixed Issues';
 $s_plugin_Source_enable_message = 'Bug Fixed Message';
 $s_plugin_Source_enable_porting = 'Porting Status';
 $s_plugin_Source_enable_product_matrix = 'Product Matrix Integration';
+$s_plugin_Source_enable_file_stats = 'File statistics <span class="small">(may be slow on large repositories)</span>';
 
 $s_plugin_Source_git_title = 'Git-based Plugins Integration';
 $s_plugin_Source_git_default_primary_branch = 'Default primary branches';

--- a/Source/lang/strings_french.txt
+++ b/Source/lang/strings_french.txt
@@ -109,6 +109,7 @@ $s_plugin_Source_enable_mapping = 'Association de branche';
 $s_plugin_Source_enable_resolving = 'Résoudre les demandes résolues';
 $s_plugin_Source_enable_message = 'Message de résolution';
 $s_plugin_Source_enable_porting = 'Etat de portage';
+$s_plugin_Source_enable_file_stats = 'Statistiques des fichiers <span class="small">(peut être lent sur les grands dépôts)</span>';
 
 $s_plugin_Source_git_title = 'Intégration de greffons basés sur Git';
 $s_plugin_Source_git_default_primary_branch = 'Branche par défaut';

--- a/Source/lang/strings_german.txt
+++ b/Source/lang/strings_german.txt
@@ -110,6 +110,7 @@ $s_plugin_Source_enable_resolving = 'Eintrag automatisch auf "Erledigt" setzen';
 $s_plugin_Source_enable_message = 'Nach dem automatischen Erledigen eine Eintragsnotiz hinzufügen';
 $s_plugin_Source_enable_porting = 'Portierungsstatus';
 $s_plugin_Source_enable_product_matrix = 'Integration von Product Matrix';
+$s_plugin_Source_enable_file_stats = 'Dateistatistiken <span class="small">(kann bei großen Repositories langsam sein)</span>';
 
 $s_plugin_Source_branch_mapping = 'Automatische Versionszuordnung';
 $s_plugin_Source_mapping_update = 'Aktualisiere Zuordnung';

--- a/Source/lang/strings_russian.txt
+++ b/Source/lang/strings_russian.txt
@@ -110,6 +110,7 @@ $s_plugin_Source_enable_resolving = 'Решать исправленные за�
 $s_plugin_Source_enable_message = 'Добавлять комментарий при решении задач';
 $s_plugin_Source_enable_porting = 'Статус портирования';
 $s_plugin_Source_enable_product_matrix = 'Интеграция с плагином Product Matrix';
+$s_plugin_Source_enable_file_stats = 'Файловая статистика <span class="маленький">(может быть медленным на больших репозиториях)</span>";
 
 $s_plugin_Source_branch_mapping = 'Маппинг веток';
 $s_plugin_Source_mapping_update = 'Обновить маппинг';

--- a/Source/lang/strings_spanish.txt
+++ b/Source/lang/strings_spanish.txt
@@ -108,6 +108,7 @@ $s_plugin_Source_enable_resolving = 'Resolver incidencias arregladas';
 $s_plugin_Source_enable_message = 'Mensaje de incidencia resuelta';
 $s_plugin_Source_enable_porting = 'Estado de portabilidad';
 $s_plugin_Source_enable_product_matrix = 'Integración de la Matriz de Producto';
+$s_plugin_Source_enable_file_stats = 'Estadísticas de archivos <span class="small">(puede ser lento en grandes repositorios)</span>';
 
 $s_plugin_Source_branch_mapping = 'Mapeados de ramas';
 $s_plugin_Source_mapping_update = 'Actualizar mapeados';

--- a/Source/pages/index.php
+++ b/Source/pages/index.php
@@ -7,6 +7,7 @@ access_ensure_global_level( plugin_config_get( 'view_threshold' ) );
 $t_can_manage = access_has_global_level( plugin_config_get( 'manage_threshold' ) );
 
 $t_show_stats = plugin_config_get( 'show_repo_stats' );
+$t_enable_file_stats = plugin_config_get( 'enable_file_stats' );
 
 $t_repos = SourceRepo::load_all();
 
@@ -48,7 +49,13 @@ layout_page_begin();
 	if( $t_show_stats ) {
 ?>
 				<th width="10%"><?php echo plugin_lang_get( 'changesets' ) ?></th>
+<?php
+		if ( $t_enable_file_stats ) {
+?>
 				<th width="10%"><?php echo plugin_lang_get( 'files' ) ?></th>
+<?php
+		}
+?>
 				<th width="10%"><?php echo plugin_lang_get( 'issues' ) ?></th>
 <?php
 	}
@@ -69,7 +76,13 @@ layout_page_begin();
 			$t_stats = $t_repo->stats();
 ?>
 				<td><?php echo $t_stats['changesets'] ?></td>
+<?php
+		if ( $t_enable_file_stats ) {
+?>
 				<td><?php echo $t_stats['files'] ?></td>
+<?php
+		}
+?>
 				<td><?php echo $t_stats['bugs'] ?></td>
 <?php
 		}

--- a/Source/pages/manage_config.php
+++ b/Source/pages/manage_config.php
@@ -22,6 +22,7 @@ $f_enable_resolving = gpc_get_bool( 'enable_resolving', OFF );
 $f_enable_message = gpc_get_bool( 'enable_message', OFF );
 $f_enable_porting = gpc_get_bool( 'enable_porting', OFF );
 $f_enable_product_matrix = gpc_get_bool( 'enable_product_matrix', OFF );
+$f_enable_file_stats = gpc_get_bool( 'enable_file_stats', OFF );
 
 $f_buglink_regex_1 = gpc_get_string( 'buglink_regex_1' );
 $f_buglink_reset_1 = gpc_get_string( 'buglink_reset_1', OFF );
@@ -87,6 +88,7 @@ maybe_set_option( 'enable_resolving', $f_enable_resolving );
 maybe_set_option( 'enable_message', $f_enable_message );
 maybe_set_option( 'enable_porting', $f_enable_porting );
 maybe_set_option( 'enable_product_matrix', $f_enable_product_matrix );
+maybe_set_option( 'enable_file_stats', $f_enable_file_stats );
 
 if ( ! $f_buglink_reset_1 ) {
 	maybe_set_option( 'buglink_regex_1', $f_buglink_regex_1 );

--- a/Source/pages/manage_config_page.php
+++ b/Source/pages/manage_config_page.php
@@ -124,6 +124,11 @@ $t_import_urls = unserialize( plugin_config_get( 'import_urls' ) );
 					check_checked( ON == plugin_config_get( 'enable_porting' ) ) ?>/>
 				<span class="lbl"> <?php echo plugin_lang_get( 'enable_porting' ) ?></span>
 			</label><br>
+			<label>
+				<input type="checkbox" name="enable_file_stats" class="ace" <?php
+					check_checked( ON == plugin_config_get( 'enable_file_stats' ) ) ?>/>
+				<span class="lbl"> <?php echo plugin_lang_get( 'enable_file_stats' ) ?></span>
+			</label><br>
 <?php
 	if( plugin_is_installed( 'ProductMatrix' ) || plugin_config_get( 'enable_product_matrix' ) ) {
 ?>

--- a/SourceGitlab/lang/strings_english.txt
+++ b/SourceGitlab/lang/strings_english.txt
@@ -13,6 +13,7 @@ $s_plugin_SourceGitlab_hub_root = 'GitLab Root<br /><span class="small">The full
 $s_plugin_SourceGitlab_hub_repoid = 'GitLab Repository ID<br /><span class="small">Numerical, filled in automatically if empty</span>';
 $s_plugin_SourceGitlab_hub_reponame = 'GitLab Repository Name<br /><span class="small">Name & Namespace with no leading or trailing slashes (namespace/project)</span>';
 $s_plugin_SourceGitlab_hub_app_secret = 'GitLab API Key<br /><span class="small">api key for mantis user (continuous user)</span>';
-$s_plugin_SourceGitlab_master_branch = 'Primary Branches<br/><span class="small">(comma-separated list or *)</span>';
+$s_plugin_SourceGitlab_master_branch = 'Allowed Branches<br/><span class="small">(comma-separated list, regular expression with /.../  or *)</span>';
+$s_plugin_SourceGitlab_import_limit = 'Import Limit<br/><span class="small">at most this many commits per import action (0: unlimited)</span>';
 
 $s_plugin_SourceGitlab_back_repo = 'Back to Repository';

--- a/SourceGitlab/lang/strings_german.txt
+++ b/SourceGitlab/lang/strings_german.txt
@@ -12,6 +12,7 @@ $s_plugin_SourceGitlab_hub_root = 'GitLab Root<br /><span class="small">The full
 $s_plugin_SourceGitlab_hub_repoid = 'GitLab Repository ID<br /><span class="small">wird über Repo Name automatisch ermittelt falls leer</span>';
 $s_plugin_SourceGitlab_hub_reponame = 'GitLab Repository Name<br /><span class="small">Ohne Namespace Slash am Anfang oder Ende (namespace/project)</span>';
 $s_plugin_SourceGitlab_hub_app_secret = 'GitLab API Key<br /><span class="small">API Schlüssel für den Mantis Benutzer (continuous Benutzer)</span>';
-$s_plugin_SourceGitlab_master_branch = 'Hauptzweige<br/><span class="small">(Komma-separierte Liste oder *)</span>';
+$s_plugin_SourceGitlab_master_branch = 'Erlaubte Branches<br/><span class="small">(Komma-separierte Liste, regulärer Ausdruck mit /.../ oder *)</span>';
+$s_plugin_SourceGitlab_import_limit = 'Import-Limit<br/><span class="small">höchstens so viele Commits pro Import-Aktion (0: unbegrenzt)</span>';
 
 $s_plugin_SourceGitlab_back_repo = 'Zurück zum Repository';

--- a/SourceGitlab/lang/strings_russian.txt
+++ b/SourceGitlab/lang/strings_russian.txt
@@ -12,6 +12,7 @@ $s_plugin_SourceGitlab_hub_root = 'GitLab URL<br /><span class="small">Адре�
 $s_plugin_SourceGitlab_hub_repoid = 'ID репозитория GitLab<br /><span class="small">Число, если пусто, будет заполнено автоматически</span>';
 $s_plugin_SourceGitlab_hub_reponame = 'Имя репозитория GitLab<br /><span class="small">Группа и имя репозитория без слэшей в начале или в конце (namespace/project)</span>';
 $s_plugin_SourceGitlab_hub_app_secret = 'Ключ API GitLab<br /><span class="small">GitLab Personal Token с уровнем доступа "api"</span>';
-$s_plugin_SourceGitlab_master_branch = 'Отслеживаемые ветки<br/><span class="small">Список веток через запятую или *</span>';
+$s_plugin_SourceGitlab_master_branch = 'Разрешенные ветви<br/><span class="small">(список, разделенный запятыми, регулярное выражение с /.../ или *)</span>";
+$s_plugin_SourceGitlab_import_limit = 'Импорт лимит<br/><span class="маленький"> в большинстве случаев это количество коммитов на одно действие по импорту (0: неограниченный)</span>";
 
 $s_plugin_SourceGitlab_back_repo = 'Назад в репозиторий';


### PR DESCRIPTION
  * list filenames to changesets
  * support more than one parent when grabbing repositories
  * put import_limit as configurable option
  * making counting of files in the overview optional, because it may take long on large repositories
  * add regexp or list filtering of branches
  * make import_limit work (as import_latest is called repeatedly)