### PR TITLE
SourceBitbucket - Fixes call to undefined method SourceBitBucketPlugin::get_default_primary_branches()

### DIFF
--- a/SourceBitBucket/SourceBitBucket.php
+++ b/SourceBitBucket/SourceBitBucket.php
@@ -3,13 +3,13 @@
 # Copyright (c) 2014 Sergey Marchenko
 # Licensed under the MIT license
 
-if( false === include_once(config_get( 'plugin_path' ) . 'Source/MantisSourcePlugin.class.php') ) {
+if( false === include_once(config_get( 'plugin_path' ) . 'Source/MantisSourceGitBasePlugin.class.php') ) {
 	return;
 }
 
 require_once(config_get( 'core_path' ) . 'json_api.php');
 
-class SourceBitBucketPlugin extends MantisSourcePlugin {
+class SourceBitBucketPlugin extends MantisSourceGitBasePlugin {
 
 	const PLUGIN_VERSION = '2.1.0';
 	const FRAMEWORK_VERSION_REQUIRED = '2.0.0';


### PR DESCRIPTION
Fixes: Call to undefined method SourceBitBucketPlugin::get_default_primary_branches() for SourceBitbucket

- Changed base class from MantisSourcePlugin to MantisSourceGitBasePlugin