### PR TITLE
SourceGitea - Timezone support for commits date

### DIFF
--- a/SourceGitea/SourceGitea.php
+++ b/SourceGitea/SourceGitea.php
@@ -375,11 +375,29 @@ class SourceGiteaPlugin extends MantisSourceGitBasePlugin {
 				$t_parents[] = $t_parent->sha;
 			}
 
+			$commit_date = $p_json->commit->author->date;
+
+			if ( substr( $commit_date, -1 ) == 'Z') {
+				$utc_commit_date = $commit_date;
+
+			} else {
+				$offset_sign = substr( $commit_date, -6, 1 );
+				$offset_time = substr( $commit_date, -5, 2 );
+				$timestamp = strtotime( $commit_date );
+
+				if ( '+' == $offset_sign ) {
+					$utc_commit_date = date( DateTime::ISO8601, $timestamp - $offset_time * 3600 );
+
+				} else {
+					$utc_commit_date = date( DateTime::ISO8601, $timestamp + $offset_time * 3600 );
+				}
+			}
+
 			$t_changeset = new SourceChangeset(
 				$p_repo->id,
 				$p_json->sha,
 				$p_branch,
-				$p_json->commit->author->date,
+				$utc_commit_date,
 				$p_json->commit->author->username ?? $p_json->commit->author->name,
 				$p_json->commit->message
 			);


### PR DESCRIPTION
Gitea API response send date in ISO8601 format with timezone informations (Z, UTC+1, UTC-2, ...).

SourceGitea don't take account of the date format and considers that commits date coming from Gitea API response are in UTC timezone leading to timezone offset in bug view page :
![exemple](https://github.com/user-attachments/assets/3a020586-e3a2-4335-b4f7-a0831b4156d9)

This pull request fix this behavior by adjusting the commit date received from Gitea API response to UTC timezone.


Best regards,

Philippe