### PR TITLE
Modify RegEx to support finding parent commit ID when GitWeb is using pathinfo formatted URLs

### DIFF
--- a/SourceGitweb/SourceGitweb.php
+++ b/SourceGitweb/SourceGitweb.php
@@ -355,7 +355,7 @@ class SourceGitwebPlugin extends MantisSourceGitBasePlugin {
 			$t_commit['message'] = trim( str_replace( '<br/>', PHP_EOL, $t_matches[6] ) );
 
 			$t_parents = array();
-			if ( preg_match_all( '#parent</td><td class="sha1"><[^>]*h=([0-9a-f]*)#', $t_gitweb_data, $t_matches ) ) {
+			if ( preg_match_all( '#parent</td><td class="sha1"><[^>]*(?:h=|/commit/)([0-9a-f]*)#', $t_gitweb_data, $t_matches ) ) {
 				foreach( $t_matches[1] as $t_match ) {
 					$t_parents[] = $t_commit['parent'] = $t_match;
 				}


### PR DESCRIPTION
Gitweb can be [configured to use pathinfo URLs](https://git-scm.com/docs/gitweb#_path_info_usage) with the gitweb.conf setting `$feature{'pathinfo'}{'default'} = [1];` and appropriate `.htaccess` changes.

In this configuration, the URLs are prettier. For example, a 'standard' Gitweb URL like this:

`https://git.example.com/?p=project.git;a=commit;h=hash_goes_here`

Will change to this:

`https://git.example.com/project.git/commit/hash_goes_here`

SourceGitweb uses RegEx to find the parent hash for a commit. The current RegEx string only works when Gitweb is creating the links on the page with 'standard' URLs. If you try to import commits from a Gitweb instance that is using pathinfo URLs, it only imports one commit (most recent) and stops there because it can't find any parents.

I have modified the RegEx string so it can find the parent hashes in both Gitweb URL modes.