### PR TITLE
Improve gitlab hudge repo import

### DIFF
--- a/Source/MantisSourceGitBasePlugin.class.php
+++ b/Source/MantisSourceGitBasePlugin.class.php
@@ -46,6 +46,7 @@ abstract class MantisSourceGitBasePlugin extends MantisSourcePlugin
 	 * Error constants
 	 */
 	const ERROR_INVALID_BRANCH = 'invalid_branch';
+	const ERROR_INVALID_DATE = 'invalid_date';
 
 	/**
 	 * Define plugin's Error strings
@@ -54,6 +55,7 @@ abstract class MantisSourceGitBasePlugin extends MantisSourcePlugin
 	public function errors() {
 		$t_errors_list = array(
 			self::ERROR_INVALID_BRANCH,
+			self::ERROR_INVALID_DATE,
 		);
 
 		foreach( $t_errors_list as $t_error ) {
@@ -131,6 +133,21 @@ abstract class MantisSourceGitBasePlugin extends MantisSourcePlugin
 		plugin_pop_current();
 		return $t_value;
 	}
+
+  /**
+	 * Validates a date
+	 * Triggers an ERROR_INVALID_DATE if date is not valid
+	 * @return void
+	 */
+	protected function validate_date($p_date) {
+		if (empty($p_date)) {
+			return;
+		}
+    if (! (bool)strtotime($p_date)) {
+			error_parameters( $p_date );
+			plugin_error( self::ERROR_INVALID_DATE );
+	}
+}
 
 	/**
 	 * Output form elements for configuration options.

--- a/Source/lang/strings_english.txt
+++ b/Source/lang/strings_english.txt
@@ -138,7 +138,9 @@ $s_plugin_Source_changeset_removed = 'Changeset removed';
 
 $s_plugin_Source_ensure_delete = 'Do you really want to delete the "%s" repository and all of its history?';
 $s_plugin_Source_ensure_import_full = 'This will import to a new copy of your repository, and then destroy the old repository data, and may require use of shell access.  Do you wish to continue?';
+$s_plugin_Source_ensure_import__full_since = 'This will import to a new copy of your repository since "%s", and then destroy the old repository data, and may require use of shell access. Do you wish to continue?';
 $s_plugin_Source_ensure_import_latest = 'This will attempt to import recent data for your repository, and may require use of shell access.  Do you wish to continue?';
+$s_plugin_Source_ensure_import_latest_since = 'This will attempt to import since "%s" for yout repository,  and may require use of shell access.  Do you wish to continue?';
 $s_plugin_Source_import_results = 'Import Results';
 $s_plugin_Source_import_stats = 'Imported %s changesets, %s files, and %s bug references.';
 $s_plugin_Source_import_repo_error = 'Import process produced an error.';
@@ -150,6 +152,7 @@ $s_plugin_Source_invalid_changeset = 'Changeset information could not be loaded'
 
 $s_plugin_Source_import_latest_failed = 'Repository latest data importing failed.';
 $s_plugin_Source_import_full_failed = 'Full repository data importing failed.';
+$s_plugin_Source_import_since_failed = 'Repository "since date" importing failed.';
 
 $s_plugin_Source_changeset_column_title = 'C';
 

--- a/Source/lang/strings_french.txt
+++ b/Source/lang/strings_french.txt
@@ -70,6 +70,7 @@ $s_plugin_Source_back_repo = 'Retour au dépôt';
 $s_plugin_Source_back_changeset = 'Retour au jeu de changements';
 $s_plugin_Source_import_full = 'Tout importer';
 $s_plugin_Source_import_latest = 'Importer les dernières données';
+$s_plugin_Source_import_since = 'Importer depuis le...';
 $s_plugin_Source_related_changesets = 'Jeux de changements liés';
 $s_plugin_Source_affected_issues = 'Demandes affectées';
 $s_plugin_Source_attach_to_issue = 'Attacher des demandes :';
@@ -134,7 +135,9 @@ $s_plugin_Source_changeset_removed = 'Jeu de changement détaché';
 
 $s_plugin_Source_ensure_delete = 'Voulez-vous vraiment supprimer le dépôt "%s" et tout son historique ?';
 $s_plugin_Source_ensure_import_full = 'Ceci va importer une nouvelle copie de votre dépôt, puis détruira les vieilles données de dépôt et pourrait avoir besoin d\'un accès au shell. Voulez-vous continuer ?';
+$s_plugin_Source_ensure_import_full_since = 'Ceci va importer une nouvelle copie de votre dépôt depuis le "%s", puis détruira les vieilles données de dépôt et pourrait avoir besoin d\'un accès au shell. Voulez-vous continuer ?';
 $s_plugin_Source_ensure_import_latest = 'Ceci va tenter d\'importer les données récentes dans votre dépôt et pourrait avoir besoin d\'un accès au shell. Voulez-vous continuer ?';
+$s_plugin_Source_ensure_import_latest_since = 'Cevi va tenter d\'importer les données depuis le "%s" dans votre dépôt et pourrait avoir besoin d\'un accès au shell. Voulez-vous continuer ?';
 $s_plugin_Source_import_results = 'Résultats de l\'import';
 $s_plugin_Source_import_stats = '%s jeux de changements importés, %s fichiers, et %s références de demande.';
 $s_plugin_Source_import_repo_error = 'Le processus d\'import a rencontré une erreur.';

--- a/Source/pages/repo_import_full.php
+++ b/Source/pages/repo_import_full.php
@@ -6,12 +6,18 @@
 form_security_validate( 'plugin_Source_repo_import_full' );
 access_ensure_global_level( plugin_config_get( 'manage_threshold' ) );
 
-$f_repo_id = gpc_get_string( 'id' );
+$f_repo_id = gpc_get_int( 'id' );
 
 $t_repo = SourceRepo::load( $f_repo_id );
 $t_vcs = SourceVCS::repo( $t_repo );
 
-helper_ensure_confirmed( plugin_lang_get( 'ensure_import_full' ), plugin_lang_get( 'import_full' ) );
+if (empty( $t_repo->info['hub_oldest_commit_date'])){
+	helper_ensure_confirmed( plugin_lang_get( 'ensure_import_full' ), plugin_lang_get( 'import_full' ) );
+}else{
+	$t_date_since = $t_repo->info['hub_oldest_commit_date'];
+	helper_ensure_confirmed( sprintf( plugin_lang_get( 'ensure_import_full_since' ), $t_date_since), plugin_lang_get( 'import_full' ) );
+}
+
 helper_begin_long_process();
 
 layout_page_header( plugin_lang_get( 'title' ) );

--- a/Source/pages/repo_manage_page.php
+++ b/Source/pages/repo_manage_page.php
@@ -177,12 +177,12 @@ layout_page_begin();
 					<form action="<?php echo plugin_page( 'repo_import_latest' ) . '&amp;id=' . $t_repo->id ?>" method="post" class="pull-right">
 						<?php echo form_security_field( 'plugin_Source_repo_import_latest' ) ?>
 						<input type="submit" class="btn btn-primary btn-white btn-sm btn-round " value="<?php echo plugin_lang_get( 'import_latest' ) ?>"/>
-					</form>
+					</form>	
 				</div>
 			</div>
 		</div>
 	</div>
-
+	
 	<div class="space-10"></div>
 
 

--- a/SourceGitlab/lang/strings_english.txt
+++ b/SourceGitlab/lang/strings_english.txt
@@ -14,6 +14,7 @@ $s_plugin_SourceGitlab_hub_repoid = 'GitLab Repository ID<br /><span class="smal
 $s_plugin_SourceGitlab_hub_reponame = 'GitLab Repository Name<br /><span class="small">Name &amp; Namespace with no leading or trailing slashes (namespace/project)</span>';
 $s_plugin_SourceGitlab_hub_app_secret = 'GitLab API Key<br /><span class="small">api key for mantis user (continuous user)</span>';
 $s_plugin_SourceGitlab_master_branch = 'Allowed Branches<br/><span class="small">(comma-separated list, regular expression with /.../  or *)</span>';
+$s_plugin_SourceGitlab_hub_oldest_commit_date = 'Import since (optional)<br/><span class="small">Oldest commit will be ignored, leave empty to import all commits</span>';
 $s_plugin_SourceGitlab_import_limit = 'Import Limit<br/><span class="small">at most this many commits per import action (0: unlimited)</span>';
 
 $s_plugin_SourceGitlab_error_api = 'GitLab API error (%1$s)';


### PR DESCRIPTION
Hi,

Here is my journey, with the `Gitlab`plugin.

First I have tried to import everithing. Because my repo is very hudge with lots of commits across to many old branches,  
the import process raise a `php memory error` : 
```txt
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 16384 bytes) in /var/www/html/vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php on line 1422
```

When I check into the database, I can see that commits have been imported.
But it was only old commits.

I have tried to configure the **Allowed branches** fields with a regex to limit the number of branches to look up but it failed.
Even after fix this issue (see commit [7528e98](https://github.com/mantisbt-plugins/source-integration/commit/7528e98ccd560d152083f2cbaad83a67377d758b)), I still have my import issue.

The root cause of my import issue is on gitlab, the [branches API](https://docs.gitlab.com/api/branches/) return only the 20 first branches of the projet.
Results are paginated. We have to iterate over this API and play with `per_page` and `page` parameters, ex :  
<https://gitlab.mycompagny.com/api/v4/projects/id/repository/branches?per_page=100&page=1">

So in commit  [c005c2f](https://github.com/mantisbt-plugins/source-integration/commit/c005c2f5cad432a06bb87dafed112c039e33a398), I propose several improvments : 
- I change import strategy. Instead of pulling all branches, and then exclude unwanted one, we pull only interested branches.
- Add a date to forbid to import oldest commits
  This date allows to limit the number of commit to import.
  On old projet, commits messages may not respects the pattern that allow link a commit with an issue. So it is no use to import then.

I hope this proposal will be intégrated in next versions.

Regards,
Nicolas 
