### PR TITLE
Replace utf8_encode() removed in PHP 8.2

### DIFF
--- a/SourceBitBucket/SourceBitBucket.php
+++ b/SourceBitBucket/SourceBitBucket.php
@@ -233,7 +233,10 @@ class SourceBitBucketPlugin extends MantisSourceGitBasePlugin {
 
 	private function api_json_url( $p_repo, $p_url ) {
 		$t_data = $this->url_get( $p_repo, $p_url );
-		$t_json = json_decode( utf8_encode( $t_data ) );
+		# PHP 8.2 removed utf8_encode(); mb_convert_encoding() is the documented
+		# drop-in replacement for ISO-8859-1 -> UTF-8 conversion.
+		$t_data = mb_convert_encoding( $t_data, 'UTF-8', 'ISO-8859-1' );
+		$t_json = json_decode( $t_data );
 		if( json_last_error() != JSON_ERROR_NONE ) {
 			error_parameters( $t_data );
 			plugin_error( self::ERROR_BITBUCKET_API );


### PR DESCRIPTION
## Summary
- `utf8_encode()` was deprecated in PHP 8.2 and removed in later versions, causing a fatal error when the BitBucket integration calls `api_json_url()` on modern PHP.
- Replaces the call in `SourceBitBucketPlugin::api_json_url()` with `mb_convert_encoding($data, 'UTF-8', 'ISO-8859-1')`, which the PHP manual lists as the direct equivalent.
- No behavioural change on PHP < 8.2: the conversion semantics (ISO-8859-1 → UTF-8) are identical.

## Why
MantisBT plugins targeting current PHP releases were breaking when BitBucket returned non-ASCII bytes (commit messages, author names, etc.) because `utf8_encode()` no longer exists.
